### PR TITLE
Adding Pylint to the Fabric MCP Server Project

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"] # Test against supported Python versions
-
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,15 @@
 # .github/workflows/test.yml
 name: Run Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master # Or your main branch name
+      - develop # Add other branches if needed
+  pull_request:
+    branches:
+      - master # Or your main branch name
+      - develop # Add other branches if needed
 
 jobs:
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,5 +26,6 @@ jobs:
         run: |
           uv run ruff format --check .
           uv run ruff check .
+          uv run pylint .
       - name: Run tests
         run: uv run pytest

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,23 @@
+[MAIN]
+
+# Specify a score threshold under which the program will exit with error.
+fail-under=9
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=.git,
+      .venv,
+      __pycache__
+
+[FORMAT]
+# Maximum number of characters on a single line.
+max-line-length=88
+
+[MESSAGES CONTROL]
+
+# Disable the message, report, category or checker with the given id(s).
+# disable=missing-docstring
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -25,7 +25,7 @@
 		{
 			"label": "Run Linter",
 			"type": "shell",
-			"command": "cd ${workspaceFolder} && ruff --check .",
+			"command": "cd ${workspaceFolder} && ruff check . && pylint .",
 			"group": {
 				"kind": "test",
 				"isDefault": true

--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@ This project implements a standalone server that bridges the gap between [Daniel
 
 Imagine seamlessly using Fabric's specialized prompts for code explanation, refactoring, or creative writing right inside your favorite tools!
 
+## Table of Contents
+
+- [Fabric MCP Server](#fabric-mcp-server)
+  - [Table of Contents](#table-of-contents)
+  - [What is this?](#what-is-this)
+  - [Key Goals \& Features (Based on Design)](#key-goals--features-based-on-design)
+  - [How it Works](#how-it-works)
+  - [Project Status](#project-status)
+  - [Getting Started](#getting-started)
+    - [Prerequisites](#prerequisites)
+    - [Installation](#installation)
+      - [From Source (for Development)](#from-source-for-development)
+      - [From PyPI (for Users)](#from-pypi-for-users)
+  - [Contributing](#contributing)
+  - [License](#license)
+
+
 ## What is this?
 
 * **Fabric:** An open-source framework for augmenting human capabilities using AI, focusing on prompt engineering and modular AI workflows.
@@ -51,6 +68,8 @@ These instructions will get you a copy of the project up and running on your loc
 
 ### Installation
 
+#### From Source (for Development)
+
 1. **Clone the repository:**
 
    ```bash
@@ -81,6 +100,20 @@ These instructions will get you a copy of the project up and running on your loc
      ```
 
 Now you have the development environment set up!
+
+#### From PyPI (for Users)
+
+If you just want to use the `fabric-mcp` server without developing it, you can install it directly from PyPI:
+
+```bash
+# Using pip
+pip install fabric-mcp
+
+# Or using uv
+uv pip install fabric-mcp
+```
+
+This will install the package and its dependencies. You can then run the server using the `fabric-mcp` command.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ Imagine seamlessly using Fabric's specialized prompts for code explanation, refa
 
 ## What is this?
 
-* **Fabric:** An open-source framework for augmenting human capabilities using AI, focusing on prompt engineering and modular AI workflows.
-* **MCP:** An open standard protocol enabling AI applications (like IDEs) to securely interact with external tools and data sources (like this server).
-* **Fabric MCP Server:** This project acts as an MCP server, translating MCP requests into calls to a running Fabric instance's REST API (`fabric --serve`).
+- **Fabric:** An open-source framework for augmenting human capabilities using AI, focusing on prompt engineering and modular AI workflows.
+- **MCP:** An open standard protocol enabling AI applications (like IDEs) to securely interact with external tools and data sources (like this server).
+- **Fabric MCP Server:** This project acts as an MCP server, translating MCP requests into calls to a running Fabric instance's REST API (`fabric --serve`).
 
 ## Key Goals & Features (Based on Design)
 
-* **Seamless Integration:** Use Fabric patterns and capabilities directly within MCP clients without switching context.
-* **Enhanced Workflows:** Empower LLMs within IDEs or other tools to leverage Fabric's specialized prompts and user configurations.
-* **Standardization:** Adhere to the open MCP standard for AI tool integration.
-* **Leverage Fabric Core:** Build upon the existing Fabric CLI and REST API without modifying the core Fabric codebase.
-* **Expose Fabric Functionality:** Provide MCP tools to list patterns, get pattern details, run patterns, list models/strategies, and retrieve configuration.
+- **Seamless Integration:** Use Fabric patterns and capabilities directly within MCP clients without switching context.
+- **Enhanced Workflows:** Empower LLMs within IDEs or other tools to leverage Fabric's specialized prompts and user configurations.
+- **Standardization:** Adhere to the open MCP standard for AI tool integration.
+- **Leverage Fabric Core:** Build upon the existing Fabric CLI and REST API without modifying the core Fabric codebase.
+- **Expose Fabric Functionality:** Provide MCP tools to list patterns, get pattern details, run patterns, list models/strategies, and retrieve configuration.
 
 ## How it Works
 
@@ -52,10 +52,10 @@ This project is currently in the **design phase**. The core architecture and pro
 
 **Next Steps:**
 
-* Select implementation language (Go/Python) and MCP library.
-* Implement the standalone MCP server.
-* Define detailed handling for streaming, variables, attachments, and errors.
-* Gather community feedback.
+- Select implementation language (Go/Python) and MCP library.
+- Implement the standalone MCP server.
+- Define detailed handling for streaming, variables, attachments, and errors.
+- Gather community feedback.
 
 ## Getting Started
 
@@ -63,8 +63,8 @@ These instructions will get you a copy of the project up and running on your loc
 
 ### Prerequisites
 
-* Python >= 3.10
-* [uv](https://github.com/astral-sh/uv) (Python package and environment manager)
+- Python >= 3.10
+- [uv](https://github.com/astral-sh/uv) (Python package and environment manager)
 
 ### Installation
 
@@ -87,13 +87,13 @@ These instructions will get you a copy of the project up and running on your loc
 
 3. **Activate the virtual environment (uv will create it if needed):**
 
-   * On macOS/Linux:
+   - On macOS/Linux:
 
      ```bash
      source .venv/bin/activate
      ```
 
-   * On Windows:
+   - On Windows:
 
      ```bash
      .venv\Scripts\activate

--- a/cspell.json
+++ b/cspell.json
@@ -2,6 +2,7 @@
 	"words": [
 		"danielmiessler",
 		"isort",
+		"levelname",
 		"listmodels",
 		"listpatterns",
 		"liststrategies",

--- a/cspell.json
+++ b/cspell.json
@@ -20,6 +20,7 @@
 		"cspell.json",
 		".gitignore",
 		".github/workflows/*.yml",
-		".ruff.toml"
+		".ruff.toml",
+		".pylintrc"
 	]
 }

--- a/fabric_mcp/__about__.py
+++ b/fabric_mcp/__about__.py
@@ -1,3 +1,3 @@
 "Version information for fabric_mcp."
 
-__version__ = "0.2.2"
+__version__ = "0.3.0"

--- a/fabric_mcp/cli.py
+++ b/fabric_mcp/cli.py
@@ -49,19 +49,11 @@ def main():
     # If --stdio is not provided, and it's not just --version or --help, show help.
     # Allow running with just --log-level if --stdio is also present.
     if not args.stdio:
-        # Check if any arguments other than known flags were passed
-        other_args = [
-            arg
+        # Show help if no arguments or only unrelated flags are provided
+        if len(sys.argv) == 1 or all(
+            arg in ["--version", "-h", "--help"] or arg.startswith("--log-level")
             for arg in sys.argv[1:]
-            if arg not in ["--version", "-h", "--help"]
-            and not arg.startswith("--log-level")
-        ]
-        if len(sys.argv) == 1 or other_args:
-            parser.print_help(sys.stderr)
-            sys.exit(1)
-        # If only --log-level (or --version/--help) was passed without --stdio,
-        # show help
-        elif not other_args and "--stdio" not in sys.argv:
+        ):
             parser.print_help(sys.stderr)
             sys.exit(1)
 

--- a/fabric_mcp/cli.py
+++ b/fabric_mcp/cli.py
@@ -2,6 +2,7 @@
 
 import argparse
 import asyncio
+import logging  # Import logging
 import sys
 
 from .__about__ import __version__
@@ -25,27 +26,58 @@ def main():
         action="store_true",
         help="Run the server in stdio mode (default).",
     )
+    parser.add_argument(
+        "-l",
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        default="INFO",
+        help="Set the logging level (default: INFO)",
+    )
     # Add other arguments and subcommands here in the future
     args = parser.parse_args()
 
-    # If no arguments are given (besides --version handled by action='version'),
-    # print help for now. Replace this with default behavior later.
-    if len(sys.argv) == 1:
-        parser.print_help(sys.stderr)
+    # Configure logging
+    numeric_level = getattr(logging, args.log_level.upper(), None)
+    if not isinstance(numeric_level, int):
+        # This should not happen with choices, but good practice
+        print(f"Invalid log level: {args.log_level}", file=sys.stderr)
         sys.exit(1)
+    logging.basicConfig(
+        level=numeric_level, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
+
+    # If --stdio is not provided, and it's not just --version or --help, show help.
+    # Allow running with just --log-level if --stdio is also present.
+    if not args.stdio:
+        # Check if any arguments other than known flags were passed
+        other_args = [
+            arg
+            for arg in sys.argv[1:]
+            if arg not in ["--version", "-h", "--help"]
+            and not arg.startswith("--log-level")
+        ]
+        if len(sys.argv) == 1 or other_args:
+            parser.print_help(sys.stderr)
+            sys.exit(1)
+        # If only --log-level (or --version/--help) was passed without --stdio,
+        # show help
+        elif not other_args and "--stdio" not in sys.argv:
+            parser.print_help(sys.stderr)
+            sys.exit(1)
 
     # Add main logic based on args here
     if args.stdio:
+        logging.info("Starting server with log level %s", args.log_level)  # Log level
         try:
+            # Logging is now configured above
             asyncio.run(run_server_stdio())
         except KeyboardInterrupt:
-            print("\nServer interrupted by user. Exiting.", file=sys.stderr)
-        except Exception as e:
-            print(f"An unexpected error occurred: {e}", file=sys.stderr)
+            logging.info("Server stopped by user.")
+            sys.exit(0)
+        except Exception:
+            # Log the full traceback for unexpected errors
+            logging.exception("An unexpected error occurred during server execution.")
             sys.exit(1)
-    else:
-        parser.print_help(sys.stderr)
-        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/fabric_mcp/cli.py
+++ b/fabric_mcp/cli.py
@@ -1,9 +1,11 @@
 "CLI entry point for fabric-mcp."
 
 import argparse
+import asyncio
 import sys
 
 from .__about__ import __version__
+from .server import run_server_stdio
 
 
 def main():
@@ -18,8 +20,13 @@ def main():
         version=f"%(prog)s {__version__}",
         help="Show the version number and exit.",
     )
+    parser.add_argument(
+        "--stdio",
+        action="store_true",
+        help="Run the server in stdio mode (default).",
+    )
     # Add other arguments and subcommands here in the future
-    _ = parser.parse_args()
+    args = parser.parse_args()
 
     # If no arguments are given (besides --version handled by action='version'),
     # print help for now. Replace this with default behavior later.
@@ -28,7 +35,17 @@ def main():
         sys.exit(1)
 
     # Add main logic based on args here
-    print("Main CLI logic would go here.")
+    if args.stdio:
+        try:
+            asyncio.run(run_server_stdio())
+        except KeyboardInterrupt:
+            print("\nServer interrupted by user. Exiting.", file=sys.stderr)
+        except Exception as e:
+            print(f"An unexpected error occurred: {e}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/fabric_mcp/mcp_protocol.py
+++ b/fabric_mcp/mcp_protocol.py
@@ -40,11 +40,21 @@ class MCPError(BaseModel):
     data: Optional[MCPErrorData] = None
 
 
+# --- Generic Response Result Field ---
+# Use Union for type hinting the 'result' field in MCPResponse
+# Add new result types to this Union as they are defined
+ResultType = Union[
+    "MCPListToolsResponse",
+    "FabricRunPatternResult",
+    # Add other result types here
+]
+
+
 class MCPResponse(BaseModel):
     """Base model for an MCP response."""
 
     jsonrpc: Literal["2.0"] = "2.0"
-    result: Optional[MCPResponseResult] = None
+    result: Optional[ResultType] = None
     error: Optional[MCPError] = None
     id: Union[str, int, None]  # Must match the request ID
 
@@ -78,5 +88,23 @@ class MCPListToolsResponse(MCPResponseResult):
     tools: List[MCPToolDefinition]
 
 
-# TODO: Add structures for other methods as they are implemented
+# fabric_run_pattern (Example - adjust based on actual Fabric output)
+class FabricRunPatternParams(BaseModel):
+    pattern_name: str = Field(..., description="The name of the pattern to run.")
+    input_text: str = Field(..., description="The primary text input for the pattern.")
+    variables: Optional[Dict[str, Any]] = Field(
+        None, description="Key-value pairs for pattern variables."
+    )
+    attachments: Optional[List[Any]] = Field(
+        None, description="List of attachments for the pattern."
+    )
+    stream: Optional[bool] = Field(False, description="Whether to stream the response.")
+
+
+class FabricRunPatternResult(BaseModel):
+    output: str  # Example: Assuming the pattern returns a single string output
+    # Add other fields as needed, e.g., cost, tokens, etc.
+
+
+# FIXME: Add structures for other methods as they are implemented
 # e.g., fabric_run_pattern, fabric_list_patterns etc.

--- a/fabric_mcp/mcp_protocol.py
+++ b/fabric_mcp/mcp_protocol.py
@@ -1,0 +1,82 @@
+"""
+Data structures for Model Context Protocol (MCP) messages.
+Based on https://modelcontextprotocol.io/specification/2025-03-26
+"""
+
+from typing import Any, Dict, List, Literal, Optional, Union
+
+from pydantic import BaseModel, Field
+
+# Based on MCP Specification 2025-03-26
+# https://modelcontextprotocol.io/specification/2025-03-26
+
+
+class MCPRequest(BaseModel):
+    """Base model for an MCP request."""
+
+    jsonrpc: Literal["2.0"] = "2.0"
+    method: str
+    params: Optional[Union[Dict[str, Any], List[Any]]] = None
+    id: Optional[Union[str, int]] = None
+
+
+class MCPResponseResult(BaseModel):
+    """Base model for a successful MCP response result."""
+
+    # Specific results will inherit from this
+
+
+class MCPErrorData(BaseModel):
+    """Optional data field for MCP errors."""
+
+    # Define specific error data structures as needed
+
+
+class MCPError(BaseModel):
+    """Structure for an MCP error response."""
+
+    code: int
+    message: str
+    data: Optional[MCPErrorData] = None
+
+
+class MCPResponse(BaseModel):
+    """Base model for an MCP response."""
+
+    jsonrpc: Literal["2.0"] = "2.0"
+    result: Optional[MCPResponseResult] = None
+    error: Optional[MCPError] = None
+    id: Union[str, int, None]  # Must match the request ID
+
+
+# --- Specific Method Payloads ---
+
+
+# list_tools
+class MCPToolParameter(BaseModel):
+    """Describes a parameter for an MCP tool."""
+
+    name: str
+    description: str
+    type: str  # e.g., "string", "number", "boolean", "object", "array"
+    required: bool = False
+    # Add other JSON schema properties if needed (e.g., enum, properties for object)
+
+
+class MCPToolDefinition(BaseModel):
+    """Describes a tool available via MCP."""
+
+    name: str
+    description: str
+    parameters: List[MCPToolParameter] = Field(default_factory=list)
+    # Add information about return type if needed
+
+
+class MCPListToolsResponse(MCPResponseResult):
+    """Result structure for the list_tools method."""
+
+    tools: List[MCPToolDefinition]
+
+
+# TODO: Add structures for other methods as they are implemented
+# e.g., fabric_run_pattern, fabric_list_patterns etc.

--- a/fabric_mcp/server.py
+++ b/fabric_mcp/server.py
@@ -1,5 +1,6 @@
 """Core MCP server logic for Fabric integration."""
 
+import asyncio
 import json
 import logging
 import sys
@@ -99,8 +100,11 @@ async def dispatch_request(request_data: Dict[str, Any]) -> Dict[str, Any]:
 async def run_server_stdio():
     """Runs the MCP server, reading from stdin and writing to stdout."""
     logging.info("MCP Server starting (stdio transport)")
+    reader = asyncio.StreamReader()
+    protocol = asyncio.StreamReaderProtocol(reader)
+    await asyncio.get_event_loop().connect_read_pipe(lambda: protocol, sys.stdin)
     while True:
-        line = sys.stdin.readline()
+        line = await reader.readline()
         if not line:
             logging.info("EOF received, shutting down.")
             break

--- a/fabric_mcp/server.py
+++ b/fabric_mcp/server.py
@@ -1,0 +1,137 @@
+"""Core MCP server logic for Fabric integration."""
+
+import json
+import logging
+import sys
+from typing import Any, Dict, Optional, Union
+
+from pydantic import ValidationError
+
+from .mcp_protocol import (
+    MCPError,
+    MCPListToolsResponse,
+    MCPRequest,
+    MCPResponse,
+    # Import other response types as needed
+)
+from .tools import get_tools
+
+# Configure basic logging
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+
+# --- Error Codes (Example) ---
+# Follow JSON-RPC 2.0 spec: https://www.jsonrpc.org/specification#error_object
+PARSE_ERROR = -32700
+INVALID_REQUEST = -32600
+METHOD_NOT_FOUND = -32601
+INVALID_PARAMS = -32602
+INTERNAL_ERROR = -32603
+# Application specific errors: -32000 to -32099
+
+
+# --- Request Handlers ---
+
+
+async def handle_list_tools(request: MCPRequest) -> MCPResponse:
+    """Handles the list_tools request."""
+    logging.info("Handling list_tools request")
+    try:
+        tools = get_tools()
+        result = MCPListToolsResponse(tools=tools)
+        return MCPResponse(result=result, id=request.id)
+    except Exception as e:
+        logging.exception("Error handling list_tools")
+        error = MCPError(code=INTERNAL_ERROR, message=f"Internal server error: {e}")
+        return MCPResponse(error=error, id=request.id)
+
+
+# --- Add handlers for other methods here ---
+# async def handle_fabric_run_pattern(request: MCPRequest) -> MCPResponse:
+#     pass # Implement later
+
+# --- Request Dispatcher ---
+
+METHOD_HANDLERS = {
+    "list_tools": handle_list_tools,
+    # "fabric_run_pattern": handle_fabric_run_pattern, # Add later
+    # ... other methods
+}
+
+
+async def dispatch_request(request_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Parses, validates, and dispatches an incoming request."""
+    request_id: Optional[Union[str, int]] = request_data.get("id")
+    try:
+        request = MCPRequest.model_validate(request_data)
+    except ValidationError as e:
+        logging.error("Invalid request format: %s", e)
+        error = MCPError(code=INVALID_REQUEST, message=f"Invalid request: {e}")
+        # ID might be null if parsing failed early
+        return MCPResponse(error=error, id=request_id).model_dump(exclude_none=True)
+
+    handler = METHOD_HANDLERS.get(request.method)
+    if not handler:
+        logging.warning("Method not found: %s", request.method)
+        error = MCPError(
+            code=METHOD_NOT_FOUND,
+            message=f"Method '{request.method}' not found",
+        )
+        return MCPResponse(error=error, id=request.id).model_dump(exclude_none=True)
+
+    try:
+        response = await handler(request)
+        return response.model_dump(exclude_none=True)
+    except Exception as e:
+        # Catch unexpected errors in handlers
+        logging.exception("Unhandled error during method execution: %s", request.method)
+        error = MCPError(
+            code=INTERNAL_ERROR,
+            message=f"Internal server error during method execution: {e}",
+        )
+        return MCPResponse(error=error, id=request.id).model_dump(exclude_none=True)
+
+
+# --- Main Server Loop (stdio) ---
+
+
+async def run_server_stdio():
+    """Runs the MCP server, reading from stdin and writing to stdout."""
+    logging.info("MCP Server starting (stdio transport)")
+    while True:
+        line = sys.stdin.readline()
+        if not line:
+            logging.info("EOF received, shutting down.")
+            break
+
+        logging.debug("Received line: %s", line.strip())
+        try:
+            request_data = json.loads(line)
+            if not isinstance(request_data, dict):
+                raise ValueError("Request must be a JSON object")
+        except json.JSONDecodeError:
+            logging.error("Failed to parse JSON: %s", line.strip())
+            error_response = MCPResponse(
+                error=MCPError(
+                    code=PARSE_ERROR, message="Failed to parse JSON request"
+                ),
+                id=None,  # ID is unknown if parsing failed
+            ).model_dump(exclude_none=True)
+            print(json.dumps(error_response), flush=True)
+            continue
+        except ValueError as e:
+            logging.error("Invalid request structure: %s", e)
+            error_response = MCPResponse(
+                error=MCPError(code=INVALID_REQUEST, message=str(e)),
+                id=request_data.get("id") if isinstance(request_data, dict) else None,
+            ).model_dump(exclude_none=True)
+            print(json.dumps(error_response), flush=True)
+            continue
+
+        response_data = await dispatch_request(request_data)
+        response_json = json.dumps(response_data)
+        logging.debug("Sending response: %s", response_json)
+        print(response_json, flush=True)
+
+    logging.info("MCP Server stopped.")

--- a/fabric_mcp/server.py
+++ b/fabric_mcp/server.py
@@ -100,6 +100,17 @@ async def dispatch_request(request_data: Dict[str, Any]) -> Dict[str, Any]:
 async def run_server_stdio():
     """Runs the MCP server, reading from stdin and writing to stdout."""
     logging.info("MCP Server starting (stdio transport)")
+    loop = asyncio.get_running_loop()
+
+    def read_stdin():
+        return sys.stdin.readline()
+
+    while True:
+        line = await loop.run_in_executor(None, read_stdin)
+        if not line:
+            logging.info("EOF received, shutting down.")
+            break
+
     reader = asyncio.StreamReader()
     await asyncio.start_unix_server(
         lambda: asyncio.StreamReaderProtocol(reader), sys.stdin.fileno()

--- a/fabric_mcp/server.py
+++ b/fabric_mcp/server.py
@@ -101,8 +101,9 @@ async def run_server_stdio():
     """Runs the MCP server, reading from stdin and writing to stdout."""
     logging.info("MCP Server starting (stdio transport)")
     reader = asyncio.StreamReader()
-    protocol = asyncio.StreamReaderProtocol(reader)
-    await asyncio.get_event_loop().connect_read_pipe(lambda: protocol, sys.stdin)
+    await asyncio.start_unix_server(
+        lambda: asyncio.StreamReaderProtocol(reader), sys.stdin.fileno()
+    )
     while True:
         line = await reader.readline()
         if not line:

--- a/fabric_mcp/tools.py
+++ b/fabric_mcp/tools.py
@@ -1,0 +1,83 @@
+"""Definitions of the tools provided by the Fabric MCP server."""
+
+from .mcp_protocol import MCPToolDefinition, MCPToolParameter
+
+# Define the tools based on the project plan (tasks.json)
+# Stubs for now, parameters will be refined later.
+
+FABRIC_TOOLS: list[MCPToolDefinition] = [
+    MCPToolDefinition(
+        name="fabric_list_patterns",
+        description="Lists available Fabric patterns.",
+        parameters=[],  # No parameters for listing
+    ),
+    MCPToolDefinition(
+        name="fabric_run_pattern",
+        description="Runs a specified Fabric pattern with given input.",
+        parameters=[
+            MCPToolParameter(
+                name="pattern_name",
+                description="The name of the pattern to run.",
+                type="string",
+                required=True,
+            ),
+            MCPToolParameter(
+                name="input_text",
+                description="The primary text input for the pattern.",
+                type="string",
+                required=True,
+            ),
+            MCPToolParameter(
+                name="variables",
+                description="Key-value pairs for pattern variables.",
+                type="object",
+                required=False,
+            ),
+            MCPToolParameter(
+                name="attachments",
+                description="List of attachments for the pattern.",
+                type="array",
+                required=False,
+            ),
+            MCPToolParameter(
+                name="stream",
+                description="Whether to stream the response.",
+                type="boolean",
+                required=False,
+            ),
+        ],
+    ),
+    MCPToolDefinition(
+        name="fabric_get_pattern_details",
+        description="Retrieves detailed information about a specific Fabric pattern.",
+        parameters=[
+            MCPToolParameter(
+                name="pattern_name",
+                description="The name of the pattern.",
+                type="string",
+                required=True,
+            ),
+        ],
+    ),
+    MCPToolDefinition(
+        name="fabric_list_models",
+        description="Lists available models configured in Fabric.",
+        parameters=[],
+    ),
+    MCPToolDefinition(
+        name="fabric_list_strategies",
+        description="Lists available strategies configured in Fabric.",
+        parameters=[],
+    ),
+    MCPToolDefinition(
+        name="fabric_get_configuration",
+        description="Retrieves the current Fabric configuration.",
+        parameters=[],
+    ),
+    # Add other tools as needed
+]
+
+
+def get_tools() -> list[MCPToolDefinition]:
+    """Returns the list of available Fabric tools."""
+    return FABRIC_TOOLS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ fabric-mcp = "fabric_mcp.cli:main"
 dev = [
     "hatch>=1.14.1",
     "hatchling>=1.27.0",
+    "pylint>=3.3.6",
     "pytest>=8.3.5",
     "ruff>=0.5.0",
     "uv>=0.7.2",

--- a/uv.lock
+++ b/uv.lock
@@ -186,6 +186,18 @@ wheels = [
 ]
 
 [[package]]
+name = "astroid"
+version = "3.3.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/33/536530122a22a7504b159bccaf30a1f76aa19d23028bd8b5009eb9b2efea/astroid-3.3.9.tar.gz", hash = "sha256:622cc8e3048684aa42c820d9d218978021c3c3d174fb03a9f0d615921744f550", size = 398731, upload-time = "2025-03-09T11:54:36.388Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/80/c749efbd8eef5ea77c7d6f1956e8fbfb51963b7f93ef79647afd4d9886e3/astroid-3.3.9-py3-none-any.whl", hash = "sha256:d05bfd0acba96a7bd43e222828b7d9bc1e138aaeb0649707908d3702a9831248", size = 275339, upload-time = "2025-03-09T11:54:34.489Z" },
+]
+
+[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -438,47 +450,58 @@ wheels = [
 
 [[package]]
 name = "cryptography"
-version = "44.0.2"
+version = "44.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/25/4ce80c78963834b8a9fd1cc1266be5ed8d1840785c0f2e1b73b8d128d505/cryptography-44.0.2.tar.gz", hash = "sha256:c63454aa261a0cf0c5b4718349629793e9e634993538db841165b3df74f37ec0", size = 710807, upload-time = "2025-03-02T00:01:37.692Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/d6/1411ab4d6108ab167d06254c5be517681f1e331f90edf1379895bcb87020/cryptography-44.0.3.tar.gz", hash = "sha256:fe19d8bc5536a91a24a8133328880a41831b6c5df54599a8417b62fe015d3053", size = 711096, upload-time = "2025-05-02T19:36:04.667Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/ef/83e632cfa801b221570c5f58c0369db6fa6cef7d9ff859feab1aae1a8a0f/cryptography-44.0.2-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:efcfe97d1b3c79e486554efddeb8f6f53a4cdd4cf6086642784fa31fc384e1d7", size = 6676361, upload-time = "2025-03-02T00:00:06.528Z" },
-    { url = "https://files.pythonhosted.org/packages/30/ec/7ea7c1e4c8fc8329506b46c6c4a52e2f20318425d48e0fe597977c71dbce/cryptography-44.0.2-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29ecec49f3ba3f3849362854b7253a9f59799e3763b0c9d0826259a88efa02f1", size = 3952350, upload-time = "2025-03-02T00:00:09.537Z" },
-    { url = "https://files.pythonhosted.org/packages/27/61/72e3afdb3c5ac510330feba4fc1faa0fe62e070592d6ad00c40bb69165e5/cryptography-44.0.2-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc821e161ae88bfe8088d11bb39caf2916562e0a2dc7b6d56714a48b784ef0bb", size = 4166572, upload-time = "2025-03-02T00:00:12.03Z" },
-    { url = "https://files.pythonhosted.org/packages/26/e4/ba680f0b35ed4a07d87f9e98f3ebccb05091f3bf6b5a478b943253b3bbd5/cryptography-44.0.2-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:3c00b6b757b32ce0f62c574b78b939afab9eecaf597c4d624caca4f9e71e7843", size = 3958124, upload-time = "2025-03-02T00:00:14.518Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/e8/44ae3e68c8b6d1cbc59040288056df2ad7f7f03bbcaca6b503c737ab8e73/cryptography-44.0.2-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7bdcd82189759aba3816d1f729ce42ffded1ac304c151d0a8e89b9996ab863d5", size = 3678122, upload-time = "2025-03-02T00:00:17.212Z" },
-    { url = "https://files.pythonhosted.org/packages/27/7b/664ea5e0d1eab511a10e480baf1c5d3e681c7d91718f60e149cec09edf01/cryptography-44.0.2-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:4973da6ca3db4405c54cd0b26d328be54c7747e89e284fcff166132eb7bccc9c", size = 4191831, upload-time = "2025-03-02T00:00:19.696Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/07/79554a9c40eb11345e1861f46f845fa71c9e25bf66d132e123d9feb8e7f9/cryptography-44.0.2-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:4e389622b6927d8133f314949a9812972711a111d577a5d1f4bee5e58736b80a", size = 3960583, upload-time = "2025-03-02T00:00:22.488Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/6d/858e356a49a4f0b591bd6789d821427de18432212e137290b6d8a817e9bf/cryptography-44.0.2-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:f514ef4cd14bb6fb484b4a60203e912cfcb64f2ab139e88c2274511514bf7308", size = 4191753, upload-time = "2025-03-02T00:00:25.038Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/80/62df41ba4916067fa6b125aa8c14d7e9181773f0d5d0bd4dcef580d8b7c6/cryptography-44.0.2-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1bc312dfb7a6e5d66082c87c34c8a62176e684b6fe3d90fcfe1568de675e6688", size = 4079550, upload-time = "2025-03-02T00:00:26.929Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/cd/2558cc08f7b1bb40683f99ff4327f8dcfc7de3affc669e9065e14824511b/cryptography-44.0.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3b721b8b4d948b218c88cb8c45a01793483821e709afe5f622861fc6182b20a7", size = 4298367, upload-time = "2025-03-02T00:00:28.735Z" },
-    { url = "https://files.pythonhosted.org/packages/71/59/94ccc74788945bc3bd4cf355d19867e8057ff5fdbcac781b1ff95b700fb1/cryptography-44.0.2-cp37-abi3-win32.whl", hash = "sha256:51e4de3af4ec3899d6d178a8c005226491c27c4ba84101bfb59c901e10ca9f79", size = 2772843, upload-time = "2025-03-02T00:00:30.592Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/2c/0d0bbaf61ba05acb32f0841853cfa33ebb7a9ab3d9ed8bb004bd39f2da6a/cryptography-44.0.2-cp37-abi3-win_amd64.whl", hash = "sha256:c505d61b6176aaf982c5717ce04e87da5abc9a36a5b39ac03905c4aafe8de7aa", size = 3209057, upload-time = "2025-03-02T00:00:33.393Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/be/7a26142e6d0f7683d8a382dd963745e65db895a79a280a30525ec92be890/cryptography-44.0.2-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:8e0ddd63e6bf1161800592c71ac794d3fb8001f2caebe0966e77c5234fa9efc3", size = 6677789, upload-time = "2025-03-02T00:00:36.009Z" },
-    { url = "https://files.pythonhosted.org/packages/06/88/638865be7198a84a7713950b1db7343391c6066a20e614f8fa286eb178ed/cryptography-44.0.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:81276f0ea79a208d961c433a947029e1a15948966658cf6710bbabb60fcc2639", size = 3951919, upload-time = "2025-03-02T00:00:38.581Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/fc/99fe639bcdf58561dfad1faa8a7369d1dc13f20acd78371bb97a01613585/cryptography-44.0.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a1e657c0f4ea2a23304ee3f964db058c9e9e635cc7019c4aa21c330755ef6fd", size = 4167812, upload-time = "2025-03-02T00:00:42.934Z" },
-    { url = "https://files.pythonhosted.org/packages/53/7b/aafe60210ec93d5d7f552592a28192e51d3c6b6be449e7fd0a91399b5d07/cryptography-44.0.2-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6210c05941994290f3f7f175a4a57dbbb2afd9273657614c506d5976db061181", size = 3958571, upload-time = "2025-03-02T00:00:46.026Z" },
-    { url = "https://files.pythonhosted.org/packages/16/32/051f7ce79ad5a6ef5e26a92b37f172ee2d6e1cce09931646eef8de1e9827/cryptography-44.0.2-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d1c3572526997b36f245a96a2b1713bf79ce99b271bbcf084beb6b9b075f29ea", size = 3679832, upload-time = "2025-03-02T00:00:48.647Z" },
-    { url = "https://files.pythonhosted.org/packages/78/2b/999b2a1e1ba2206f2d3bca267d68f350beb2b048a41ea827e08ce7260098/cryptography-44.0.2-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b042d2a275c8cee83a4b7ae30c45a15e6a4baa65a179a0ec2d78ebb90e4f6699", size = 4193719, upload-time = "2025-03-02T00:00:51.397Z" },
-    { url = "https://files.pythonhosted.org/packages/72/97/430e56e39a1356e8e8f10f723211a0e256e11895ef1a135f30d7d40f2540/cryptography-44.0.2-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:d03806036b4f89e3b13b6218fefea8d5312e450935b1a2d55f0524e2ed7c59d9", size = 3960852, upload-time = "2025-03-02T00:00:53.317Z" },
-    { url = "https://files.pythonhosted.org/packages/89/33/c1cf182c152e1d262cac56850939530c05ca6c8d149aa0dcee490b417e99/cryptography-44.0.2-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c7362add18b416b69d58c910caa217f980c5ef39b23a38a0880dfd87bdf8cd23", size = 4193906, upload-time = "2025-03-02T00:00:56.49Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/99/87cf26d4f125380dc674233971069bc28d19b07f7755b29861570e513650/cryptography-44.0.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:8cadc6e3b5a1f144a039ea08a0bdb03a2a92e19c46be3285123d32029f40a922", size = 4081572, upload-time = "2025-03-02T00:00:59.995Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/9f/6a3e0391957cc0c5f84aef9fbdd763035f2b52e998a53f99345e3ac69312/cryptography-44.0.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6f101b1f780f7fc613d040ca4bdf835c6ef3b00e9bd7125a4255ec574c7916e4", size = 4298631, upload-time = "2025-03-02T00:01:01.623Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/a5/5bc097adb4b6d22a24dea53c51f37e480aaec3465285c253098642696423/cryptography-44.0.2-cp39-abi3-win32.whl", hash = "sha256:3dc62975e31617badc19a906481deacdeb80b4bb454394b4098e3f2525a488c5", size = 2773792, upload-time = "2025-03-02T00:01:04.133Z" },
-    { url = "https://files.pythonhosted.org/packages/33/cf/1f7649b8b9a3543e042d3f348e398a061923ac05b507f3f4d95f11938aa9/cryptography-44.0.2-cp39-abi3-win_amd64.whl", hash = "sha256:5f6f90b72d8ccadb9c6e311c775c8305381db88374c65fa1a68250aa8a9cb3a6", size = 3210957, upload-time = "2025-03-02T00:01:06.987Z" },
-    { url = "https://files.pythonhosted.org/packages/99/10/173be140714d2ebaea8b641ff801cbcb3ef23101a2981cbf08057876f89e/cryptography-44.0.2-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:af4ff3e388f2fa7bff9f7f2b31b87d5651c45731d3e8cfa0944be43dff5cfbdb", size = 3396886, upload-time = "2025-03-02T00:01:09.51Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/b4/424ea2d0fce08c24ede307cead3409ecbfc2f566725d4701b9754c0a1174/cryptography-44.0.2-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:0529b1d5a0105dd3731fa65680b45ce49da4d8115ea76e9da77a875396727b41", size = 3892387, upload-time = "2025-03-02T00:01:11.348Z" },
-    { url = "https://files.pythonhosted.org/packages/28/20/8eaa1a4f7c68a1cb15019dbaad59c812d4df4fac6fd5f7b0b9c5177f1edd/cryptography-44.0.2-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:7ca25849404be2f8e4b3c59483d9d3c51298a22c1c61a0e84415104dacaf5562", size = 4109922, upload-time = "2025-03-02T00:01:13.934Z" },
-    { url = "https://files.pythonhosted.org/packages/11/25/5ed9a17d532c32b3bc81cc294d21a36c772d053981c22bd678396bc4ae30/cryptography-44.0.2-pp310-pypy310_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:268e4e9b177c76d569e8a145a6939eca9a5fec658c932348598818acf31ae9a5", size = 3895715, upload-time = "2025-03-02T00:01:16.895Z" },
-    { url = "https://files.pythonhosted.org/packages/63/31/2aac03b19c6329b62c45ba4e091f9de0b8f687e1b0cd84f101401bece343/cryptography-44.0.2-pp310-pypy310_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:9eb9d22b0a5d8fd9925a7764a054dca914000607dff201a24c791ff5c799e1fa", size = 4109876, upload-time = "2025-03-02T00:01:18.751Z" },
-    { url = "https://files.pythonhosted.org/packages/99/ec/6e560908349843718db1a782673f36852952d52a55ab14e46c42c8a7690a/cryptography-44.0.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:2bf7bf75f7df9715f810d1b038870309342bff3069c5bd8c6b96128cb158668d", size = 3131719, upload-time = "2025-03-02T00:01:21.269Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/d7/f30e75a6aa7d0f65031886fa4a1485c2fbfe25a1896953920f6a9cfe2d3b/cryptography-44.0.2-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:909c97ab43a9c0c0b0ada7a1281430e4e5ec0458e6d9244c0e821bbf152f061d", size = 3887513, upload-time = "2025-03-02T00:01:22.911Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/b4/7a494ce1032323ca9db9a3661894c66e0d7142ad2079a4249303402d8c71/cryptography-44.0.2-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:96e7a5e9d6e71f9f4fca8eebfd603f8e86c5225bb18eb621b2c1e50b290a9471", size = 4107432, upload-time = "2025-03-02T00:01:24.701Z" },
-    { url = "https://files.pythonhosted.org/packages/45/f8/6b3ec0bc56123b344a8d2b3264a325646d2dcdbdd9848b5e6f3d37db90b3/cryptography-44.0.2-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d1b3031093a366ac767b3feb8bcddb596671b3aaff82d4050f984da0c248b615", size = 3891421, upload-time = "2025-03-02T00:01:26.335Z" },
-    { url = "https://files.pythonhosted.org/packages/57/ff/f3b4b2d007c2a646b0f69440ab06224f9cf37a977a72cdb7b50632174e8a/cryptography-44.0.2-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:04abd71114848aa25edb28e225ab5f268096f44cf0127f3d36975bdf1bdf3390", size = 4107081, upload-time = "2025-03-02T00:01:28.938Z" },
+    { url = "https://files.pythonhosted.org/packages/08/53/c776d80e9d26441bb3868457909b4e74dd9ccabd182e10b2b0ae7a07e265/cryptography-44.0.3-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:962bc30480a08d133e631e8dfd4783ab71cc9e33d5d7c1e192f0b7c06397bb88", size = 6670281, upload-time = "2025-05-02T19:34:50.665Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/06/af2cf8d56ef87c77319e9086601bef621bedf40f6f59069e1b6d1ec498c5/cryptography-44.0.3-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ffc61e8f3bf5b60346d89cd3d37231019c17a081208dfbbd6e1605ba03fa137", size = 3959305, upload-time = "2025-05-02T19:34:53.042Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/01/80de3bec64627207d030f47bf3536889efee8913cd363e78ca9a09b13c8e/cryptography-44.0.3-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58968d331425a6f9eedcee087f77fd3c927c88f55368f43ff7e0a19891f2642c", size = 4171040, upload-time = "2025-05-02T19:34:54.675Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/48/bb16b7541d207a19d9ae8b541c70037a05e473ddc72ccb1386524d4f023c/cryptography-44.0.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e28d62e59a4dbd1d22e747f57d4f00c459af22181f0b2f787ea83f5a876d7c76", size = 3963411, upload-time = "2025-05-02T19:34:56.61Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b2/7d31f2af5591d217d71d37d044ef5412945a8a8e98d5a2a8ae4fd9cd4489/cryptography-44.0.3-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:af653022a0c25ef2e3ffb2c673a50e5a0d02fecc41608f4954176f1933b12359", size = 3689263, upload-time = "2025-05-02T19:34:58.591Z" },
+    { url = "https://files.pythonhosted.org/packages/25/50/c0dfb9d87ae88ccc01aad8eb93e23cfbcea6a6a106a9b63a7b14c1f93c75/cryptography-44.0.3-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:157f1f3b8d941c2bd8f3ffee0af9b049c9665c39d3da9db2dc338feca5e98a43", size = 4196198, upload-time = "2025-05-02T19:35:00.988Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c9/55c6b8794a74da652690c898cb43906310a3e4e4f6ee0b5f8b3b3e70c441/cryptography-44.0.3-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:c6cd67722619e4d55fdb42ead64ed8843d64638e9c07f4011163e46bc512cf01", size = 3966502, upload-time = "2025-05-02T19:35:03.091Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f7/7cb5488c682ca59a02a32ec5f975074084db4c983f849d47b7b67cc8697a/cryptography-44.0.3-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b424563394c369a804ecbee9b06dfb34997f19d00b3518e39f83a5642618397d", size = 4196173, upload-time = "2025-05-02T19:35:05.018Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/0b/2f789a8403ae089b0b121f8f54f4a3e5228df756e2146efdf4a09a3d5083/cryptography-44.0.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c91fc8e8fd78af553f98bc7f2a1d8db977334e4eea302a4bfd75b9461c2d8904", size = 4087713, upload-time = "2025-05-02T19:35:07.187Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/aa/330c13655f1af398fc154089295cf259252f0ba5df93b4bc9d9c7d7f843e/cryptography-44.0.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:25cd194c39fa5a0aa4169125ee27d1172097857b27109a45fadc59653ec06f44", size = 4299064, upload-time = "2025-05-02T19:35:08.879Z" },
+    { url = "https://files.pythonhosted.org/packages/10/a8/8c540a421b44fd267a7d58a1fd5f072a552d72204a3f08194f98889de76d/cryptography-44.0.3-cp37-abi3-win32.whl", hash = "sha256:3be3f649d91cb182c3a6bd336de8b61a0a71965bd13d1a04a0e15b39c3d5809d", size = 2773887, upload-time = "2025-05-02T19:35:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/0d/c4b1657c39ead18d76bbd122da86bd95bdc4095413460d09544000a17d56/cryptography-44.0.3-cp37-abi3-win_amd64.whl", hash = "sha256:3883076d5c4cc56dbef0b898a74eb6992fdac29a7b9013870b34efe4ddb39a0d", size = 3209737, upload-time = "2025-05-02T19:35:12.12Z" },
+    { url = "https://files.pythonhosted.org/packages/34/a3/ad08e0bcc34ad436013458d7528e83ac29910943cea42ad7dd4141a27bbb/cryptography-44.0.3-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:5639c2b16764c6f76eedf722dbad9a0914960d3489c0cc38694ddf9464f1bb2f", size = 6673501, upload-time = "2025-05-02T19:35:13.775Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f0/7491d44bba8d28b464a5bc8cc709f25a51e3eac54c0a4444cf2473a57c37/cryptography-44.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3ffef566ac88f75967d7abd852ed5f182da252d23fac11b4766da3957766759", size = 3960307, upload-time = "2025-05-02T19:35:15.917Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/c8/e5c5d0e1364d3346a5747cdcd7ecbb23ca87e6dea4f942a44e88be349f06/cryptography-44.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:192ed30fac1728f7587c6f4613c29c584abdc565d7417c13904708db10206645", size = 4170876, upload-time = "2025-05-02T19:35:18.138Z" },
+    { url = "https://files.pythonhosted.org/packages/73/96/025cb26fc351d8c7d3a1c44e20cf9a01e9f7cf740353c9c7a17072e4b264/cryptography-44.0.3-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:7d5fe7195c27c32a64955740b949070f21cba664604291c298518d2e255931d2", size = 3964127, upload-time = "2025-05-02T19:35:19.864Z" },
+    { url = "https://files.pythonhosted.org/packages/01/44/eb6522db7d9f84e8833ba3bf63313f8e257729cf3a8917379473fcfd6601/cryptography-44.0.3-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3f07943aa4d7dad689e3bb1638ddc4944cc5e0921e3c227486daae0e31a05e54", size = 3689164, upload-time = "2025-05-02T19:35:21.449Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fb/d61a4defd0d6cee20b1b8a1ea8f5e25007e26aeb413ca53835f0cae2bcd1/cryptography-44.0.3-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:cb90f60e03d563ca2445099edf605c16ed1d5b15182d21831f58460c48bffb93", size = 4198081, upload-time = "2025-05-02T19:35:23.187Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/50/457f6911d36432a8811c3ab8bd5a6090e8d18ce655c22820994913dd06ea/cryptography-44.0.3-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ab0b005721cc0039e885ac3503825661bd9810b15d4f374e473f8c89b7d5460c", size = 3967716, upload-time = "2025-05-02T19:35:25.426Z" },
+    { url = "https://files.pythonhosted.org/packages/35/6e/dca39d553075980ccb631955c47b93d87d27f3596da8d48b1ae81463d915/cryptography-44.0.3-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:3bb0847e6363c037df8f6ede57d88eaf3410ca2267fb12275370a76f85786a6f", size = 4197398, upload-time = "2025-05-02T19:35:27.678Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/9d/d1f2fe681eabc682067c66a74addd46c887ebacf39038ba01f8860338d3d/cryptography-44.0.3-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b0cc66c74c797e1db750aaa842ad5b8b78e14805a9b5d1348dc603612d3e3ff5", size = 4087900, upload-time = "2025-05-02T19:35:29.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f5/3599e48c5464580b73b236aafb20973b953cd2e7b44c7c2533de1d888446/cryptography-44.0.3-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6866df152b581f9429020320e5eb9794c8780e90f7ccb021940d7f50ee00ae0b", size = 4301067, upload-time = "2025-05-02T19:35:31.547Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6c/d2c48c8137eb39d0c193274db5c04a75dab20d2f7c3f81a7dcc3a8897701/cryptography-44.0.3-cp39-abi3-win32.whl", hash = "sha256:c138abae3a12a94c75c10499f1cbae81294a6f983b3af066390adee73f433028", size = 2775467, upload-time = "2025-05-02T19:35:33.805Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ad/51f212198681ea7b0deaaf8846ee10af99fba4e894f67b353524eab2bbe5/cryptography-44.0.3-cp39-abi3-win_amd64.whl", hash = "sha256:5d186f32e52e66994dce4f766884bcb9c68b8da62d61d9d215bfe5fb56d21334", size = 3210375, upload-time = "2025-05-02T19:35:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/10/abcf7418536df1eaba70e2cfc5c8a0ab07aa7aa02a5cbc6a78b9d8b4f121/cryptography-44.0.3-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:cad399780053fb383dc067475135e41c9fe7d901a97dd5d9c5dfb5611afc0d7d", size = 3393192, upload-time = "2025-05-02T19:35:37.468Z" },
+    { url = "https://files.pythonhosted.org/packages/06/59/ecb3ef380f5891978f92a7f9120e2852b1df6f0a849c277b8ea45b865db2/cryptography-44.0.3-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:21a83f6f35b9cc656d71b5de8d519f566df01e660ac2578805ab245ffd8523f8", size = 3898419, upload-time = "2025-05-02T19:35:39.065Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d0/35e2313dbb38cf793aa242182ad5bc5ef5c8fd4e5dbdc380b936c7d51169/cryptography-44.0.3-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:fc3c9babc1e1faefd62704bb46a69f359a9819eb0292e40df3fb6e3574715cd4", size = 4117892, upload-time = "2025-05-02T19:35:40.839Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c8/31fb6e33b56c2c2100d76de3fd820afaa9d4d0b6aea1ccaf9aaf35dc7ce3/cryptography-44.0.3-pp310-pypy310_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:e909df4053064a97f1e6565153ff8bb389af12c5c8d29c343308760890560aff", size = 3900855, upload-time = "2025-05-02T19:35:42.599Z" },
+    { url = "https://files.pythonhosted.org/packages/43/2a/08cc2ec19e77f2a3cfa2337b429676406d4bb78ddd130a05c458e7b91d73/cryptography-44.0.3-pp310-pypy310_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:dad80b45c22e05b259e33ddd458e9e2ba099c86ccf4e88db7bbab4b747b18d06", size = 4117619, upload-time = "2025-05-02T19:35:44.774Z" },
+    { url = "https://files.pythonhosted.org/packages/02/68/fc3d3f84022a75f2ac4b1a1c0e5d6a0c2ea259e14cd4aae3e0e68e56483c/cryptography-44.0.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:479d92908277bed6e1a1c69b277734a7771c2b78633c224445b5c60a9f4bc1d9", size = 3136570, upload-time = "2025-05-02T19:35:46.94Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/4b/c11ad0b6c061902de5223892d680e89c06c7c4d606305eb8de56c5427ae6/cryptography-44.0.3-pp311-pypy311_pp73-macosx_10_9_x86_64.whl", hash = "sha256:896530bc9107b226f265effa7ef3f21270f18a2026bc09fed1ebd7b66ddf6375", size = 3390230, upload-time = "2025-05-02T19:35:49.062Z" },
+    { url = "https://files.pythonhosted.org/packages/58/11/0a6bf45d53b9b2290ea3cec30e78b78e6ca29dc101e2e296872a0ffe1335/cryptography-44.0.3-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:9b4d4a5dbee05a2c390bf212e78b99434efec37b17a4bff42f50285c5c8c9647", size = 3895216, upload-time = "2025-05-02T19:35:51.351Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/27/b28cdeb7270e957f0077a2c2bfad1b38f72f1f6d699679f97b816ca33642/cryptography-44.0.3-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:02f55fb4f8b79c1221b0961488eaae21015b69b210e18c386b69de182ebb1259", size = 4115044, upload-time = "2025-05-02T19:35:53.044Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b0/ec4082d3793f03cb248881fecefc26015813199b88f33e3e990a43f79835/cryptography-44.0.3-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:dd3db61b8fe5be220eee484a17233287d0be6932d056cf5738225b9c05ef4fff", size = 3898034, upload-time = "2025-05-02T19:35:54.72Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7f/adf62e0b8e8d04d50c9a91282a57628c00c54d4ae75e2b02a223bd1f2613/cryptography-44.0.3-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:978631ec51a6bbc0b7e58f23b68a8ce9e5f09721940933e9c217068388789fe5", size = 4114449, upload-time = "2025-05-02T19:35:57.139Z" },
+    { url = "https://files.pythonhosted.org/packages/87/62/d69eb4a8ee231f4bf733a92caf9da13f1c81a44e874b1d4080c25ecbb723/cryptography-44.0.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:5d20cc348cca3a8aa7312f42ab953a56e15323800ca3ab0706b8cd452a3a056c", size = 3134369, upload-time = "2025-05-02T19:35:58.907Z" },
+]
+
+[[package]]
+name = "dill"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/80/630b4b88364e9a8c8c5797f4602d0f76ef820909ee32f0bacb9f90654042/dill-0.4.0.tar.gz", hash = "sha256:0633f1d2df477324f53a895b02c901fb961bdbf65a17122586ea7019292cbcf0", size = 186976, upload-time = "2025-04-16T00:41:48.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/3d/9373ad9c56321fdab5b41197068e1d8c25883b3fea29dd361f9b55116869/dill-0.4.0-py3-none-any.whl", hash = "sha256:44f54bf6412c2c8464c14e8243eb163690a9800dbe2c367330883b19c7561049", size = 119668, upload-time = "2025-04-16T00:41:47.671Z" },
 ]
 
 [[package]]
@@ -529,6 +552,7 @@ dependencies = [
 dev = [
     { name = "hatch" },
     { name = "hatchling" },
+    { name = "pylint" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "uv" },
@@ -544,6 +568,7 @@ requires-dist = [
 dev = [
     { name = "hatch", specifier = ">=1.14.1" },
     { name = "hatchling", specifier = ">=1.27.0" },
+    { name = "pylint", specifier = ">=3.3.6" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "ruff", specifier = ">=0.5.0" },
     { name = "uv", specifier = ">=0.7.2" },
@@ -908,7 +933,7 @@ wheels = [
 
 [[package]]
 name = "groq"
-version = "0.23.1"
+version = "0.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -918,9 +943,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/b1/653567a92d876e3e52cdce6780ac3f6dfec5101b6c81a577e3c5abddeebe/groq-0.23.1.tar.gz", hash = "sha256:952e34895f9bfb78ab479e495d77b32180262e5c42f531ce3a1722d6e5a04dfb", size = 125359, upload-time = "2025-04-24T18:59:32.562Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/23/d71f076e9fd5f4f8989387c0bca3b5fd02c5eaa17f8fe0777fe0940d2d80/groq-0.24.0.tar.gz", hash = "sha256:e821559de8a77fb81d2585b3faec80ff923d6d64fd52339b33f6c94997d6f7f5", size = 125654, upload-time = "2025-05-02T16:13:31.01Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/9a/54948664261f707a24377ee7e280dbca52b7265fce8613c52dae0cbf5cf5/groq-0.23.1-py3-none-any.whl", hash = "sha256:05fa38c3d0ad03c19c6185f98f6a73901c2a463e844fd067b79f7b05c8346946", size = 127351, upload-time = "2025-04-24T18:59:30.809Z" },
+    { url = "https://files.pythonhosted.org/packages/98/f0/faa2a007981d74c3e0fe141d07e4ed43b95fed00d3b8489696602b51119d/groq-0.24.0-py3-none-any.whl", hash = "sha256:0020e6b0b2b267263c9eb7c318deef13c12f399c6525734200b11d777b00088e", size = 127536, upload-time = "2025-05-02T16:13:29.493Z" },
 ]
 
 [[package]]
@@ -1127,7 +1152,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
@@ -1141,6 +1166,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "isort"
+version = "6.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/21/1e2a441f74a653a144224d7d21afe8f4169e6c7c20bb13aec3a2dc3815e0/isort-6.0.1.tar.gz", hash = "sha256:1cb5df28dfbc742e490c5e41bad6da41b805b0a8be7bc93cd0fb2a8a890ac450", size = 821955, upload-time = "2025-02-26T21:13:16.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/11/114d0a5f4dabbdcedc1125dee0888514c3c3b16d3e9facad87ed96fad97c/isort-6.0.1-py3-none-any.whl", hash = "sha256:2dc5d7f65c9678d94c88dfc29161a320eec67328bc97aad576874cb4be1e9615", size = 94186, upload-time = "2025-02-26T21:13:14.911Z" },
 ]
 
 [[package]]
@@ -1297,6 +1331,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
 ]
 
 [[package]]
@@ -1547,7 +1590,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "1.76.2"
+version = "1.77.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1559,9 +1602,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/48/e767710b07acc1fca1f6b8cacd743102c71b8fdeca603876de0749ec00f1/openai-1.76.2.tar.gz", hash = "sha256:f430c8b848775907405c6eff54621254c96f6444c593c097e0cc3a9f8fdda96f", size = 434922, upload-time = "2025-04-29T20:02:56.294Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c0/ea2e9a78bf88404b97e7b708f0823b4699ab2ee3f5564425b8531a890a43/openai-1.77.0.tar.gz", hash = "sha256:897969f927f0068b8091b4b041d1f8175bcf124f7ea31bab418bf720971223bc", size = 435778, upload-time = "2025-05-02T19:17:27.971Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/5f/aecb820917e93ca9fcac408e998dc22ee0561c308ed58dc8f328e3f7ef14/openai-1.76.2-py3-none-any.whl", hash = "sha256:9c1d9ad59e6e3bea7205eedc9ca66eeebae18d47b527e505a2b0d2fb1538e26e", size = 661253, upload-time = "2025-04-29T20:02:54.362Z" },
+    { url = "https://files.pythonhosted.org/packages/90/58/37ae3ca75936b824a0a5ca30491c968192007857319d6836764b548b9d9b/openai-1.77.0-py3-none-any.whl", hash = "sha256:07706e91eb71631234996989a8ea991d5ee56f0744ef694c961e0824d4f39218", size = 662031, upload-time = "2025-05-02T19:17:26.151Z" },
 ]
 
 [[package]]
@@ -2047,6 +2090,25 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pylint"
+version = "3.3.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "astroid" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "dill" },
+    { name = "isort" },
+    { name = "mccabe" },
+    { name = "platformdirs" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomlkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/a7/113d02340afb9dcbb0c8b25454e9538cd08f0ebf3e510df4ed916caa1a89/pylint-3.3.6.tar.gz", hash = "sha256:b634a041aac33706d56a0d217e6587228c66427e20ec21a019bc4cdee48c040a", size = 1519586, upload-time = "2025-03-20T11:25:38.207Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/21/9537fc94aee9ec7316a230a49895266cf02d78aa29b0a2efbc39566e0935/pylint-3.3.6-py3-none-any.whl", hash = "sha256:8b7c2d3e86ae3f94fb27703d521dd0b9b6b378775991f504d7c3a6275aa0a6a6", size = 522462, upload-time = "2025-03-20T11:25:36.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR adds Pylint as a secondary linting tool alongside Ruff to enhance code quality and maintainability. The implementation includes a basic `.pylintrc` configuration file, integration with CI workflows, and updates to VS Code tasks for local development. Additionally, the PR implements the core MCP server functionality with JSON-RPC protocol support over stdio transport.

## Files Changed

### Configuration Files
- Added `.pylintrc` with a baseline configuration including a score threshold of 9.0 and line length matching Ruff (88 chars)
- Updated `.github/workflows/tests.yml` to run Pylint in CI
- Updated `.vscode/tasks.json` to run both Ruff and Pylint in the linter task
- Added `.pylintrc` to the ignored files in `cspell.json`
- Updated `pyproject.toml` to include Pylint as a dev dependency

### Core Implementation
- Added `fabric_mcp/mcp_protocol.py` with Pydantic models for MCP protocol messages
- Added `fabric_mcp/server.py` with the core server implementation for stdio transport
- Added `fabric_mcp/tools.py` with definitions of Fabric tools exposed via MCP
- Updated `fabric_mcp/cli.py` to support the `--stdio` command-line option

### Documentation
- Updated `README.md` to use consistent list formatting (hyphen-style lists)

## Code Changes

The most significant changes are the addition of three new modules:

1. **MCP Protocol Models**: Implemented using Pydantic for type safety and validation:
```python
class MCPRequest(BaseModel):
    """Base model for an MCP request."""
    jsonrpc: Literal["2.0"] = "2.0"
    method: str
    params: Optional[Union[Dict[str, Any], List[Any]]] = None
    id: Optional[Union[str, int]] = None
```

2. **Server Implementation**: Added a stdio-based JSON-RPC server:
```python
async def run_server_stdio():
    """Runs the MCP server, reading from stdin and writing to stdout."""
    logging.info("MCP Server starting (stdio transport)")
    while True:
        line = sys.stdin.readline()
        if not line:
            logging.info("EOF received, shutting down.")
            break
        # Process JSON-RPC requests...
```

3. **Tool Definitions**: Added initial definitions for Fabric tools:
```python
FABRIC_TOOLS: list[MCPToolDefinition] = [
    MCPToolDefinition(
        name="fabric_list_patterns",
        description="Lists available Fabric patterns.",
        parameters=[],  # No parameters for listing
    ),
    # Additional tools...
]
```

## Reason for Changes

1. **Enhanced Code Quality**: Adding Pylint provides additional static analysis beyond what Ruff offers, helping to catch potential issues and enforce coding standards.

2. **MCP Protocol Implementation**: The new modules implement the core functionality needed for the Fabric MCP server to communicate with clients using the Model Context Protocol.

3. **Standardized Development Environment**: The updated configuration ensures all developers and CI systems run the same linting tools with consistent settings.

## Impact of Changes

- **Code Quality**: More thorough linting will help maintain a high-quality codebase as the project grows.
- **Functionality**: The server implementation provides the foundation for the Fabric MCP server, with a working stdio transport mechanism.
- **Developer Experience**: Updated VS Code tasks make it easier to run both linters locally.

## Test Plan

- The CI workflow will now run both Ruff and Pylint to verify code quality.
- The server implementation includes error handling and logging to help with debugging.
- The stdio transport can be tested manually by running `fabric-mcp --stdio` and sending JSON-RPC requests.

## Additional Notes

- The implementation currently only supports the `list_tools` method. Other methods like `fabric_run_pattern` are defined but not yet implemented.
- The Pylint threshold is set to 9.0, which is relatively strict but achievable with the current codebase.
- Dependencies in `uv.lock` were updated to their latest versions, including cryptography, groq, and openai packages.
