### PR TITLE
ci: enforce pull requests to main originate from develop branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,4 +34,19 @@ jobs:
           uv run ruff check .
           uv run pylint .
       - name: Run tests
-        run: uv run pytest
+        run: uv run pytest -v
+
+  check_pr_source:
+    name: Check PR Source Branch
+    runs-on: ubuntu-latest
+    # Only run this check for pull requests targeting the main branch
+    if: github.base_ref == 'main' && github.event_name == 'pull_request'
+    steps:
+      - name: Verify source branch is develop
+        run: |
+          if [[ "${{ github.head_ref }}" != "develop" ]]; then
+            echo "Error: Pull requests targeting 'main' must originate from the 'develop' branch."
+            exit 1
+          else
+            echo "Source branch is 'develop'. Check passed."
+          fi

--- a/fabric_mcp/__about__.py
+++ b/fabric_mcp/__about__.py
@@ -1,3 +1,3 @@
 "Version information for fabric_mcp."
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"


### PR DESCRIPTION
# PR Description: Enhance CI Workflow and Bump Version

## Summary

This pull request introduces improvements to the CI workflow defined in `.github/workflows/tests.yml` and increments the package version. The key changes include adding verbose output to pytest runs and implementing a check to ensure pull requests targeting the `main` branch originate from the `develop` branch.

## Files Changed

1.  **`.github/workflows/tests.yml`**:
    *   Modified the `Run tests` step to include the `-v` flag for pytest, providing more detailed test output.
    *   Added a new job `check_pr_source` to enforce a specific branching strategy for pull requests targeting `main`.
2.  **`fabric_mcp/__about__.py`**:
    *   Incremented the `__version__` from `0.4.2` to `0.4.3`.

## Code Changes

*   **Verbose Test Output:**
    In `.github/workflows/tests.yml`, the test execution command was updated:
    ```diff
    -        run: uv run pytest
    +        run: uv run pytest -v
    ```
*   **PR Source Branch Check:**
    A new job `check_pr_source` was added to `.github/workflows/tests.yml`:
    ```yaml
      check_pr_source:
        name: Check PR Source Branch
        runs-on: ubuntu-latest
        # Only run this check for pull requests targeting the main branch
        if: github.base_ref == 'main' && github.event_name == 'pull_request'
        steps:
          - name: Verify source branch is develop
            run: |
              if [[ "${{ github.head_ref }}" != "develop" ]]; then
                echo "Error: Pull requests targeting 'main' must originate from the 'develop' branch."
                exit 1
              else
                echo "Source branch is 'develop'. Check passed."
              fi
    ```
    This job specifically runs on PRs to `main` and fails if the source branch is not `develop`.

*   **Version Bump:**
    In `fabric_mcp/__about__.py`, the version was updated:
    ```diff
    -__version__ = "0.4.2"
    +__version__ = "0.4.3"

    ```

## Reason for Changes

*   **Improved Debugging**: Adding the `-v` flag to `pytest` provides more detailed output during CI runs, making it easier to diagnose test failures.
*   **Branching Strategy Enforcement**: The new `check_pr_source` job enforces our development workflow where features/fixes are merged into `develop` first, and only `develop` is merged into `main` for releases. This helps maintain the stability of the `main` branch.
*   **Release Preparation**: The version bump prepares the package for a new release incorporating these CI improvements.

## Impact of Changes

*   CI test logs will be more informative.
*   Pull requests attempting to merge branches other than `develop` directly into `main` will be blocked by the CI check, enforcing the intended workflow.
*   The package version is updated, signifying the inclusion of these changes.

## Test Plan

1.  **Verbose Output**: Trigger the workflow (e.g., by pushing to a branch in a PR) and observe the "Run tests" step logs to confirm verbose pytest output.
2.  **PR Check (Failure Case)**: Create a test PR targeting `main` from a branch *other than* `develop`. Verify that the `Check PR Source Branch` job fails with the expected error message.
3.  **PR Check (Success Case)**: Create a test PR targeting `main` from the `develop` branch. Verify that the `Check PR Source Branch` job passes.
4.  **Version**: Check the `fabric_mcp/__about__.py` file to confirm the version is correctly updated.

## Additional Notes

This change reinforces a Gitflow-like branching model where `main` represents the stable release history and `develop` serves as the integration branch for upcoming releases.
