### PR TITLE
Introduce Fabric API Client to interact with Fabric REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Imagine seamlessly using Fabric's specialized prompts for code explanation, refa
     - [Installation](#installation)
       - [From Source (for Development)](#from-source-for-development)
       - [From PyPI (for Users)](#from-pypi-for-users)
+  - [Configuration (Environment Variables)](#configuration-environment-variables)
   - [Contributing](#contributing)
   - [License](#license)
 
@@ -42,19 +43,16 @@ Imagine seamlessly using Fabric's specialized prompts for code explanation, refa
 2. The Host discovers available tools (like `fabric_run_pattern`) via MCP's `list_tools()` mechanism.
 3. When the user invokes a tool (e.g., asking the IDE's AI assistant to refactor code using a Fabric pattern), the Host sends an MCP request to this server.
 4. The **Fabric MCP Server** translates the MCP request into a corresponding REST API call to a running `fabric --serve` instance.
-5. The `fabric --serve` instance processes the request (e.g., executes the pattern).
+5. The `fabric --serve` instance executes the pattern.
 6. The **Fabric MCP Server** receives the response (potentially streaming) from Fabric and translates it back into an MCP response for the Host.
 
 ## Project Status
 
-This project is currently in the **design phase**. The core architecture and proposed tools are outlined in the [High-Level Design Document](./docs/design.md).
+This project is currently in the **implementation** phase.
 
-**Next Steps:**
+The core architecture and proposed tools are outlined in the [High-Level Design Document][tasks_list].
 
-- Select implementation language (Go/Python) and MCP library.
-- Implement the standalone MCP server.
-- Define detailed handling for streaming, variables, attachments, and errors.
-- Gather community feedback.
+The current task list is in the [tasks directory][tasks_directory] and is managed by the excellent [Task Master][taskmaster] tool.
 
 ## Getting Started
 
@@ -114,9 +112,32 @@ uv pip install fabric-mcp
 
 This will install the package and its dependencies. You can then run the server using the `fabric-mcp` command.
 
+## Configuration (Environment Variables)
+
+The `fabric-mcp` server can be configured using the following environment variables:
+
+- **`FABRIC_BASE_URL`**: The base URL of the running Fabric REST API server (`fabric --serve`).
+  - *Default*: `http://127.0.0.1:8080`
+- **`FABRIC_API_KEY`**: The API key required to authenticate with the Fabric REST API server, if it's configured to require one.
+  - *Default*: None (Authentication is not attempted if not set).
+- **`FABRIC_MCP_LOG_LEVEL`**: Sets the logging verbosity for the `fabric-mcp` server itself.
+  - *Options*: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` (case-insensitive).
+  - *Default*: `INFO`
+
+You can set these variables in your shell environment (or put them into a `.env` file in the working directory) before running `fabric-mcp`:
+
+```bash
+export FABRIC_BASE_URL="http://your-fabric-host:port"
+# This must match the key used by fabric --serve
+export FABRIC_API_KEY="your_secret_api_key"
+export FABRIC_MCP_LOG_LEVEL="DEBUG"
+
+fabric-mcp --stdio
+```
+
 ## Contributing
 
-Feedback on the [design document](./docs/design.md) is highly welcome! Please open an issue to share your thoughts or suggestions.
+Feedback on the [design document][tasks_list] is highly welcome! Please open an issue to share your thoughts or suggestions.
 
 Read the [contribution document here](./docs/contributing.md) and please follow the guidelines for this repository.
 
@@ -126,3 +147,6 @@ Copyright (c) 2025, [Kayvan Sylvan](kayvan@sylvan.com) Licensed under the [MIT L
 
 [fabricGithubLink]: https://github.com/danielmiessler/fabric
 [MCP]: https://modelcontextprotocol.io/
+[taskmaster]: https://github.com/eyaltoledano/claude-task-master
+[tasks_list]: ./docs/design.md
+[tasks_directory]: ./tasks

--- a/cspell.json
+++ b/cspell.json
@@ -5,6 +5,7 @@
 		"danielmiessler",
 		"excinfo",
 		"fastmcp",
+		"forcelist",
 		"isort",
 		"levelname",
 		"listmodels",

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -63,7 +63,8 @@ We welcome contributions to this project! Please follow these guidelines:
     Open a pull request from your fork's branch to the `develop` branch of the main project repository. Ensure the pull request description clearly explains the changes and references any relevant issues.
 
     > NOTE: The PR *must* be based off `develop`. The `main` branch is our stable branch and
-    `develop` is fixes and new features.
+    `develop` is for fixes and new features. Any pull request based on `main` will be auto-rejected
+    by our CI/CD pipeline.
 
 ## Code Style
 

--- a/fabric_mcp/__about__.py
+++ b/fabric_mcp/__about__.py
@@ -1,3 +1,3 @@
 "Version information for fabric_mcp."
 
-__version__ = "0.4.4"
+__version__ = "0.5.0"

--- a/fabric_mcp/api_client.py
+++ b/fabric_mcp/api_client.py
@@ -43,8 +43,9 @@ class FabricApiClient:
         self.timeout = timeout
 
         if not self.api_key:
-            logger.warning("Fabric API key not provided.")
-            logger.warning("If necessary, set the FABRIC_API_KEY environment variable.")
+            logger.warning(
+                "Fabric API key not provided. If needed, set FABRIC_API_KEY variable."
+            )
 
         self.session = requests.Session()
         # Basic user agent

--- a/fabric_mcp/api_client.py
+++ b/fabric_mcp/api_client.py
@@ -1,5 +1,6 @@
 """Fabric API Client for Python"""
 
+import json
 import os
 from typing import Any, Dict, Optional
 
@@ -189,7 +190,7 @@ if __name__ == "__main__":
             # This specific call might raise JSONDecodeError
             print(api_response.json())
         # Catch JSON decoding errors specifically first
-        except requests.exceptions.JSONDecodeError as e:
+        except (requests.exceptions.JSONDecodeError, json.JSONDecodeError) as e:
             print(f"Failed to decode JSON response: {e}")
             # Optionally print the raw text if decoding fails
             if api_response is not None:

--- a/fabric_mcp/api_client.py
+++ b/fabric_mcp/api_client.py
@@ -178,9 +178,9 @@ if __name__ == "__main__":
         client = FabricApiClient()
         api_response = None
         try:
-            # Example: Try to get models (adjust endpoint if needed)
+            # Example: Try to get list of strategies
             print("Attempting to connect to Fabric API...")
-            api_response = client.get("/models/names")  # Use renamed variable
+            api_response = client.get("/strategies")
             print("Successfully connected and received response:")
             # This specific call might raise JSONDecodeError
             print(api_response.json())

--- a/fabric_mcp/api_client.py
+++ b/fabric_mcp/api_client.py
@@ -43,8 +43,8 @@ class FabricApiClient:
         self.timeout = timeout
 
         if not self.api_key:
-            # Consider raising an error or allowing unauthenticated requests
-            logger.warning("Fabric API key not provided. Authentication will fail.")
+            logger.warning("Fabric API key not provided.")
+            logger.warning("If necessary, set the FABRIC_API_KEY environment variable.")
 
         self.session = requests.Session()
         # Basic user agent
@@ -58,7 +58,6 @@ class FabricApiClient:
             total=3,
             backoff_factor=0.3,
             status_forcelist=[500, 502, 503, 504],  # Retry on server errors
-            # Break long list onto multiple lines
             allowed_methods=[
                 "HEAD",
                 "GET",

--- a/fabric_mcp/api_client.py
+++ b/fabric_mcp/api_client.py
@@ -8,6 +8,7 @@ import requests  # Grouped external imports
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
+from fabric_mcp import __version__ as fabric_mcp_version
 from fabric_mcp.utils import Log
 
 logger = Log().logger
@@ -49,7 +50,9 @@ class FabricApiClient:
 
         self.session = requests.Session()
         # Basic user agent
-        self.session.headers.update({"User-Agent": "FabricMCPClient/0.1"})
+        self.session.headers.update(
+            {"User-Agent": f"FabricMCPClient/v{fabric_mcp_version}"}
+        )
         if self.api_key:
             # Add Auth header
             self.session.headers.update({self.FABRIC_API_HEADER: f"{self.api_key}"})

--- a/fabric_mcp/api_client.py
+++ b/fabric_mcp/api_client.py
@@ -18,6 +18,9 @@ DEFAULT_TIMEOUT = 30  # seconds
 class FabricApiClient:
     """Client for interacting with the Fabric REST API."""
 
+    FABRIC_API_HEADER = "X-API-Key"
+    REDACTED_HEADERS = ["Authorization", FABRIC_API_HEADER]
+
     def __init__(
         self,
         base_url: Optional[str] = None,
@@ -47,7 +50,7 @@ class FabricApiClient:
         self.session.headers.update({"User-Agent": "FabricMCPClient/0.1"})
         if self.api_key:
             # Add Auth header
-            self.session.headers.update({"X-API-Key": f"{self.api_key}"})
+            self.session.headers.update({self.FABRIC_API_HEADER: f"{self.api_key}"})
 
         # Configure retry strategy
         retry_strategy = Retry(
@@ -103,8 +106,9 @@ class FabricApiClient:
 
         # Mask API key in logs
         log_headers = request_headers.copy()
-        if "Authorization" in log_headers:
-            log_headers["Authorization"] = "Bearer ***REDACTED***"
+        for header in self.REDACTED_HEADERS:
+            if header in log_headers:
+                log_headers[header] = "***REDACTED***"
 
         logger.debug("Request: %s %s", method, url)
         logger.debug("Headers: %s", log_headers)

--- a/fabric_mcp/api_client.py
+++ b/fabric_mcp/api_client.py
@@ -35,7 +35,7 @@ class FabricApiClient:
             base_url: The base URL for the Fabric API. Defaults to env
                       FABRIC_BASE_URL or DEFAULT_BASE_URL.
             api_key: The API key for authentication. Defaults to env FABRIC_API_KEY.
-            region: The region for the Fabric service (placeholder).
+
             timeout: Request timeout in seconds.
         """
         self.base_url = base_url or os.environ.get("FABRIC_BASE_URL", DEFAULT_BASE_URL)

--- a/fabric_mcp/api_client.py
+++ b/fabric_mcp/api_client.py
@@ -1,0 +1,198 @@
+"""Fabric API Client for Python"""
+
+import os
+from typing import Any, Dict, Optional
+
+import requests  # Grouped external imports
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+from fabric_mcp.utils import Log
+
+logger = Log().logger
+
+DEFAULT_BASE_URL = "http://127.0.0.1:8080"  # Default for fabric --serve
+DEFAULT_TIMEOUT = 30  # seconds
+
+
+class FabricApiClient:
+    """Client for interacting with the Fabric REST API."""
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        timeout: int = DEFAULT_TIMEOUT,
+    ):
+        """
+        Initializes the Fabric API client.
+
+        Args:
+            base_url: The base URL for the Fabric API. Defaults to env
+                      FABRIC_BASE_URL or DEFAULT_BASE_URL.
+            api_key: The API key for authentication. Defaults to env FABRIC_API_KEY.
+            region: The region for the Fabric service (placeholder).
+            timeout: Request timeout in seconds.
+        """
+        self.base_url = base_url or os.environ.get("FABRIC_BASE_URL", DEFAULT_BASE_URL)
+        self.api_key = api_key or os.environ.get("FABRIC_API_KEY")
+        self.timeout = timeout
+
+        if not self.api_key:
+            # Consider raising an error or allowing unauthenticated requests
+            logger.warning("Fabric API key not provided. Authentication will fail.")
+
+        self.session = requests.Session()
+        # Basic user agent
+        self.session.headers.update({"User-Agent": "FabricMCPClient/0.1"})
+        if self.api_key:
+            # Add Auth header
+            self.session.headers.update({"X-API-Key": f"{self.api_key}"})
+
+        # Configure retry strategy
+        retry_strategy = Retry(
+            total=3,
+            backoff_factor=0.3,
+            status_forcelist=[500, 502, 503, 504],  # Retry on server errors
+            # Break long list onto multiple lines
+            allowed_methods=[
+                "HEAD",
+                "GET",
+                "OPTIONS",
+                "POST",
+                "PUT",
+                "DELETE",
+            ],  # Retry on these methods
+        )
+        adapter = HTTPAdapter(max_retries=retry_strategy)
+        self.session.mount("http://", adapter)
+        self.session.mount("https://", adapter)  # Ensure HTTPS is also covered
+
+        logger.info("FabricApiClient initialized for base URL: %s", self.base_url)
+
+    def _request(
+        self,
+        method: str,
+        endpoint: str,
+        params: Optional[Dict[str, Any]] = None,
+        json_data: Optional[Dict[str, Any]] = None,
+        data: Optional[Any] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> requests.Response:
+        """
+        Makes a request to the Fabric API.
+
+        Args:
+            method: HTTP method (e.g., 'GET', 'POST').
+            endpoint: API endpoint path (e.g., '/patterns').
+            params: URL parameters.
+            json_data: JSON payload for the request body.
+            data: Raw data for the request body.
+            headers: Additional request headers.
+
+        Returns:
+            The requests.Response object.
+
+        Raises:
+            requests.exceptions.RequestException: For connection errors, timeouts, etc.
+        """
+        url = f"{self.base_url.rstrip('/')}/{endpoint.lstrip('/')}"
+        request_headers = self.session.headers.copy()
+        if headers:
+            request_headers.update(headers)
+
+        # Mask API key in logs
+        log_headers = request_headers.copy()
+        if "Authorization" in log_headers:
+            log_headers["Authorization"] = "Bearer ***REDACTED***"
+
+        logger.debug("Request: %s %s", method, url)
+        logger.debug("Headers: %s", log_headers)
+        if params:
+            logger.debug("Params: %s", params)
+        if json_data:
+            logger.debug("JSON Body: %s", json_data)
+        elif data:
+            logger.debug("Body: <raw data>")
+
+        try:
+            response = self.session.request(
+                method=method,
+                url=url,
+                params=params,
+                json=json_data,
+                data=data,
+                headers=request_headers,
+                timeout=self.timeout,
+            )
+            logger.debug("Response Status: %s", response.status_code)
+            # Log response body carefully, might be large or sensitive
+            # logger.debug("Response Body: %s...", response.text[:500]) # Example
+
+            # Raise HTTPError for bad responses (4xx or 5xx)
+            response.raise_for_status()
+            return response
+        except requests.exceptions.RequestException as e:
+            logger.error("API request failed: %s %s - %s", method, url, e)
+            raise  # Re-raise the exception after logging
+
+    # --- Public API Methods (Wrapped signatures for line length) ---
+
+    def get(
+        self, endpoint: str, params: Optional[Dict[str, Any]] = None, **kwargs
+    ) -> requests.Response:
+        """Sends a GET request."""
+        return self._request("GET", endpoint, params=params, **kwargs)
+
+    def post(
+        self,
+        endpoint: str,
+        json_data: Optional[Dict[str, Any]] = None,
+        data: Optional[Any] = None,
+        **kwargs,
+    ) -> requests.Response:
+        """Sends a POST request."""
+        return self._request("POST", endpoint, json_data=json_data, data=data, **kwargs)
+
+    def put(
+        self,
+        endpoint: str,
+        json_data: Optional[Dict[str, Any]] = None,
+        data: Optional[Any] = None,
+        **kwargs,
+    ) -> requests.Response:
+        """Sends a PUT request."""
+        return self._request("PUT", endpoint, json_data=json_data, data=data, **kwargs)
+
+    def delete(self, endpoint: str, **kwargs) -> requests.Response:
+        """Sends a DELETE request."""
+        return self._request("DELETE", endpoint, **kwargs)
+
+
+# Example usage (optional, for testing)
+if __name__ == "__main__":
+
+    def main():
+        """Main function to demonstrate the Fabric API client."""
+        # Assumes FABRIC_API_KEY is set in the environment
+        client = FabricApiClient()
+        api_response = None
+        try:
+            # Example: Try to get models (adjust endpoint if needed)
+            print("Attempting to connect to Fabric API...")
+            api_response = client.get("/models/names")  # Use renamed variable
+            print("Successfully connected and received response:")
+            # This specific call might raise JSONDecodeError
+            print(api_response.json())
+        # Catch JSON decoding errors specifically first
+        except requests.exceptions.JSONDecodeError as e:
+            print(f"Failed to decode JSON response: {e}")
+            # Optionally print the raw text if decoding fails
+            if api_response is not None:
+                print(f"Raw response text: {api_response.text[:500]}...")
+        # Catch other request-related errors (Connection, Timeout, HTTPError, etc.)
+        except requests.exceptions.RequestException as e:
+            print(f"Failed to connect or get response: {e}")
+        # Removed the generic 'except Exception' for the example
+
+    main()

--- a/fabric_mcp/cli.py
+++ b/fabric_mcp/cli.py
@@ -54,7 +54,7 @@ def main():
 
     # Add main logic based on args here
     if args.stdio:
-        logger.info("Starting server with log level %s", args.log_level)
+        logger.info("Starting server with log level %s", log.level_name)
         fabric_mcp = FabricMCP(log_level=log.level_name)
         fabric_mcp.stdio()
         logger.info("Server stopped.")

--- a/fabric_mcp/utils.py
+++ b/fabric_mcp/utils.py
@@ -8,7 +8,14 @@ from rich.logging import RichHandler
 
 
 class Log:
-    """Custom class to handle logging set up and log levels."""
+    """
+    Custom class to handle logging setup and log levels.
+
+    This class initializes a logger with a specified log level. If no log level is
+    provided during initialization, the class attempts to use the `FABRIC_MCP_LOG_LEVEL`
+    environment variable as a fallback. If the environment variable is not set, the
+    default log level is `INFO`.
+    """
 
     def __init__(self, level: str = ""):
         """Initialize the Log class with a specific log level."""

--- a/fabric_mcp/utils.py
+++ b/fabric_mcp/utils.py
@@ -1,6 +1,7 @@
 """Utility functions for the fabric_mcp module."""
 
 import logging
+import os
 
 from rich.console import Console
 from rich.logging import RichHandler
@@ -9,8 +10,9 @@ from rich.logging import RichHandler
 class Log:
     """Custom class to handle logging set up and log levels."""
 
-    def __init__(self, level: str = "info"):
+    def __init__(self, level: str = ""):
         """Initialize the Log class with a specific log level."""
+        level = os.environ.get("FABRIC_MCP_LOG_LEVEL", level) or "INFO"
         self._level_name = level.upper()
         self._level = Log.log_level(self._level_name)
 

--- a/fabric_mcp/utils.py
+++ b/fabric_mcp/utils.py
@@ -9,7 +9,7 @@ from rich.logging import RichHandler
 class Log:
     """Custom class to handle logging set up and log levels."""
 
-    def __init__(self, level: str):
+    def __init__(self, level: str = "info"):
         """Initialize the Log class with a specific log level."""
         self._level_name = level.upper()
         self._level = Log.log_level(self._level_name)

--- a/tasks/task_003.txt
+++ b/tasks/task_003.txt
@@ -16,7 +16,7 @@
 Create unit tests with mock responses for each Fabric API endpoint. Test error handling by simulating various failure scenarios.
 
 # Subtasks:
-## 1. Implement Core API Client Infrastructure [pending]
+## 1. Implement Core API Client Infrastructure [in-progress]
 ### Dependencies: None
 ### Description: Create the foundational API client class with configuration management, authentication, and base HTTP methods
 ### Details:

--- a/tasks/tasks.json
+++ b/tasks/tasks.json
@@ -85,7 +85,7 @@
           "description": "Create the foundational API client class with configuration management, authentication, and base HTTP methods",
           "dependencies": [],
           "details": "1. Create a `FabricApiClient` class with configurable base URL, API key, and region parameters\n2. Implement session management with connection pooling for performance optimization\n3. Set up authentication headers using the Fabric API key\n4. Create base HTTP methods (GET, POST, PUT, DELETE) with proper error handling\n5. Implement retry logic with exponential backoff for transient failures (3 retries with 0.3 backoff factor)\n6. Add request/response logging with sensitive data redaction\n7. Create a configuration mechanism for API endpoint and credentials (support environment variables and config files)\n8. Add proper timeout handling to prevent hanging processes\n9. Write unit tests using mocked HTTP responses to verify core functionality\n10. Ensure all HTTP connections use HTTPS for security",
-          "status": "pending",
+          "status": "in-progress",
           "parentTaskId": 3
         },
         {

--- a/uv.lock
+++ b/uv.lock
@@ -2409,15 +2409,15 @@ wheels = [
 
 [[package]]
 name = "sse-starlette"
-version = "2.3.3"
+version = "2.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/35/7d8d94eb0474352d55f60f80ebc30f7e59441a29e18886a6425f0bccd0d3/sse_starlette-2.3.3.tar.gz", hash = "sha256:fdd47c254aad42907cfd5c5b83e2282be15be6c51197bf1a9b70b8e990522072", size = 17499, upload-time = "2025-04-23T19:28:25.558Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/be/7e776a29b5f712b5bd13c571256a2470fcf345c562c7b2359f2ee15d9355/sse_starlette-2.3.4.tar.gz", hash = "sha256:0ffd6bed217cdbb74a84816437c609278003998b4991cd2e6872d0b35130e4d5", size = 17522, upload-time = "2025-05-04T19:28:51.44Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/20/52fdb5ebb158294b0adb5662235dd396fc7e47aa31c293978d8d8942095a/sse_starlette-2.3.3-py3-none-any.whl", hash = "sha256:8b0a0ced04a329ff7341b01007580dd8cf71331cc21c0ccea677d500618da1e0", size = 10235, upload-time = "2025-04-23T19:28:24.115Z" },
+    { url = "https://files.pythonhosted.org/packages/43/a4/ee4a20f0b5ff34c391f3685eff7cdba1178a487766e31b04efb51bbddd87/sse_starlette-2.3.4-py3-none-any.whl", hash = "sha256:b8100694f3f892b133d0f7483acb7aacfcf6ed60f863b31947664b6dc74e529f", size = 10232, upload-time = "2025-05-04T19:28:50.199Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Introduce Fabric API Client

## 1. Summary

This pull request introduces the foundational `FabricApiClient` class, designed to interact with the Fabric REST API. It includes core functionality like session management, request retries, authentication handling, and basic HTTP methods (GET, POST, PUT, DELETE). Additionally, this PR includes minor updates to documentation, task tracking, dependencies, and logging configuration. The package version is bumped to `0.5.0` to reflect the addition of this significant new feature.

## 2. Files Changed

*   **`fabric_mcp/api_client.py` (New File):**
    *   Added the core `FabricApiClient` class.
    *   Implements session management using `requests.Session`.
    *   Configures automatic retries for transient server errors (5xx) using `urllib3.util.retry.Retry`.
    *   Handles API key authentication via `X-API-Key` header, configurable via environment variable (`FABRIC_API_KEY`) or constructor argument.
    *   Sets a default base URL (`http://127.0.0.1:8080`), configurable via environment variable (`FABRIC_BASE_URL`) or constructor argument.
    *   Includes basic logging for requests and responses (with API key redaction).
    *   Provides standard HTTP methods (`get`, `post`, `put`, `delete`).
    *   Includes an example usage block under `if __name__ == "__main__":`.
*   **`fabric_mcp/utils.py`:**
    *   Modified the `Log` class constructor to default the logging level to `"info"` if not explicitly provided, simplifying its initialization.
*   **`fabric_mcp/__about__.py`:**
    *   Incremented `__version__` from `0.4.4` to `0.5.0`.
*   **`docs/contributing.md`:**
    *   Clarified that pull requests must be based on the `develop` branch and that PRs based on `main` will be automatically rejected by CI/CD.
*   **`cspell.json`:**
    *   Added `"forcelist"` to the dictionary to allow the word used in the retry configuration.
*   **`tasks/task_003.txt` & `tasks/tasks.json`:**
    *   Updated the status of Task 3, Subtask 1 ("Implement Core API Client Infrastructure") from `pending` to `in-progress`.
*   **`uv.lock`:**
    *   Updated the locked version of `sse-starlette` from `2.3.3` to `2.3.4`.

## 3. Code Changes

The primary change is the introduction of the `FabricApiClient`:

```python
# fabric_mcp/api_client.py

import os
from typing import Any, Dict, Optional

import requests
from requests.adapters import HTTPAdapter
from urllib3.util.retry import Retry

from fabric_mcp.utils import Log

logger = Log().logger # Uses the updated Log class with default level

DEFAULT_BASE_URL = "http://127.0.0.1:8080"
DEFAULT_TIMEOUT = 30

class FabricApiClient:
    # ... (Initialization with base_url, api_key, timeout from env/args) ...

    def __init__(...):
        # ... (Setup base_url, api_key, timeout) ...
        if not self.api_key:
            logger.warning("Fabric API key not provided. Authentication will fail.")

        self.session = requests.Session()
        self.session.headers.update({"User-Agent": "FabricMCPClient/0.1"})
        if self.api_key:
            self.session.headers.update({"X-API-Key": f"{self.api_key}"})

        # Configure retry strategy
        retry_strategy = Retry(
            total=3,
            backoff_factor=0.3,
            status_forcelist=[500, 502, 503, 504], # Retry on these server errors
            allowed_methods=["HEAD", "GET", "OPTIONS", "POST", "PUT", "DELETE"], # Retry on these methods
        )
        adapter = HTTPAdapter(max_retries=retry_strategy)
        self.session.mount("http://", adapter)
        self.session.mount("https://", adapter) # Covers both protocols

        logger.info("FabricApiClient initialized for base URL: %s", self.base_url)

    def _request(...):
        # ... (Constructs URL, manages headers, logs request details) ...
        log_headers = request_headers.copy()
        if "Authorization" in log_headers: # Example redaction (adjust if using different auth)
            log_headers["Authorization"] = "Bearer ***REDACTED***"
        if "X-API-Key" in log_headers: # Specific redaction for this client
             log_headers["X-API-Key"] = "***REDACTED***"
        # ... (Logging) ...
        try:
            response = self.session.request(...)
            response.raise_for_status() # Raise exceptions for 4xx/5xx responses
            return response
        except requests.exceptions.RequestException as e:
            logger.error("API request failed: %s %s - %s", method, url, e)
            raise

    # Public methods (get, post, put, delete) wrap _request
    def get(...): return self._request("GET", ...)
    def post(...): return self._request("POST", ...)
    # ... etc ...

# Example usage
if __name__ == "__main__":
    # ... (Demonstrates client usage and error handling) ...
```

The logging utility was updated for convenience:

```python
# fabric_mcp/utils.py
class Log:
    # ...
    def __init__(self, level: str = "info"): # Added default value "info"
        self._level_name = level.upper()
        # ...
```

## 4. Reason for Changes

This change implements the first subtask of Task 3 ("Develop Fabric API Client Module"). The goal is to provide a standardized, robust, and reusable client for interacting with the Fabric backend API, which will be used by other components within `fabric-mcp`. Key requirements addressed include configuration via environment variables, authentication, error handling, and request retries.

## 5. Impact of Changes

*   **New Functionality:** Enables programmatic interaction with the Fabric API.
*   **Dependencies:** Adds `requests` and `urllib3` (implicitly via `requests`) as runtime dependencies.
*   **Configuration:** Relies on `FABRIC_BASE_URL` and `FABRIC_API_KEY` environment variables for default configuration. Warns if the API key is missing but does not prevent instantiation.
*   **Error Handling:** API calls will now raise `requests.exceptions.RequestException` (or its subclasses like `HTTPError`) on connection issues or non-2xx responses, which calling code must handle.
*   **Versioning:** Bumps the package version to `0.5.0`, indicating a minor release with new features.

## 6. Test Plan

*   **Manual Testing:** The example code block (`if __name__ == "__main__":`) in `api_client.py` was used for basic manual testing against a locally running Fabric instance (`fabric --serve`). Verified connection, successful GET request (`/models/names`), and error handling for connection failures and JSON decoding errors.
*   **Future Testing:** Unit tests with mocked HTTP responses should be added as part of subsequent subtasks for Task 3 to cover various API interactions and error scenarios (e.g., 4xx errors, different response types, timeout conditions).

Running Fabric on a different machine:

```plaintext
$ ssh shakti
Microsoft Windows [Version 10.0.26100.3915]
(c) Microsoft Corporation. All rights reserved.

kayvan@SHAKTI C:\Users\kayvan>fabric --serve --api-key qazwsx123
[GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
 - using env:   export GIN_MODE=release
 - using code:  gin.SetMode(gin.ReleaseMode)

[GIN-debug] GET    /patterns/:name           --> github.com/danielmiessler/fabric/restapi.NewStorageHandler[...].func1 (4 handlers)
[GIN-debug] GET    /patterns/names           --> github.com/danielmiessler/fabric/restapi.NewStorageHandler[...].func2 (4 handlers)
[GIN-debug] DELETE /patterns/:name           --> github.com/danielmiessler/fabric/restapi.NewStorageHandler[...].func3 (
[...]
```

And running the test Fabric client test code like this:

![image](https://github.com/user-attachments/assets/03c0f72b-b770-4565-87cc-bfda3cec06e5)

Back at the console where `fabric --serve` is running, we see:

![image](https://github.com/user-attachments/assets/40850149-7cba-4df6-a8a1-41348a9192f3)

## 7. Additional Notes

*   The API key is currently sent via the `X-API-Key` header, as is common for many APIs. Ensure this matches the Fabric API's expected authentication mechanism.
*   The retry strategy targets common server-side transient errors (5xx). Client-side errors (4xx) are not retried by default.
*   The update to `contributing.md` reinforces existing branching strategy rules.
