### PR TITLE
Refactor API Client to use HTTPX and Update Dependencies

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -7,6 +7,7 @@
 		"fastmcp",
 		"forcelist",
 		"isort",
+		"keepalive",
 		"ksylvan",
 		"levelname",
 		"listmodels",

--- a/cspell.json
+++ b/cspell.json
@@ -7,6 +7,7 @@
 		"fastmcp",
 		"forcelist",
 		"isort",
+		"ksylvan",
 		"levelname",
 		"listmodels",
 		"listpatterns",

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -66,6 +66,55 @@ We welcome contributions to this project! Please follow these guidelines:
     `develop` is for fixes and new features. Any pull request based on `main` will be auto-rejected
     by our CI/CD pipeline.
 
+### Details about the CI/CD Pipeline
+
+There are two Rulesets that are enabled:
+
+#### Main branch deletion protection
+
+```plaintext
+Main Branch
+ID: 5272788
+Source: ksylvan/python-project-template (Repository)
+Enforcement: Active
+You can bypass: never
+
+Bypass List
+This ruleset cannot be bypassed
+
+Conditions
+- ref_name: [exclude: []] [include: [refs/heads/main]]
+
+Rules
+- deletion
+- non_fast_forward
+- required_status_checks: [do_not_enforce_on_create: false] [required_status_checks: [map[context:tests (3.11) integration_id:15368] map[context:tests (3.12) integration_id:15368] map[context:Check PR Source Branch integration_id:15368]]] [strict_required_status_checks_policy: true]
+
+```
+
+#### Merge into Develop
+
+```plaintext
+
+Merge Into Develop
+ID: 5259640
+Source: ksylvan/fabric-mcp (Repository)
+Enforcement: Active
+You can bypass: never
+
+Bypass List
+This ruleset cannot be bypassed
+
+Conditions
+- ref_name: [exclude: []] [include: [refs/heads/develop]]
+
+Rules
+- deletion
+- non_fast_forward
+- pull_request: [allowed_merge_methods: [merge squash rebase]] [automatic_copilot_code_review_enabled: false] [dismiss_stale_reviews_on_push: false] [require_code_owner_review: false] [require_last_push_approval: false] [required_approving_review_count: 0] [required_review_thread_resolution: true]
+- required_status_checks: [do_not_enforce_on_create: false] [required_status_checks: [map[context:tests (3.11) integration_id:15368] map[context:tests (3.12) integration_id:15368]]] [strict_required_status_checks_policy: false]
+```
+
 ## Code Style
 
 Please follow the existing code style. We use `ruff` for formatting and quick linting, and `pylint` for more thorough static analysis. We also use `pyright` with `strict` level type checking.

--- a/fabric_mcp/__about__.py
+++ b/fabric_mcp/__about__.py
@@ -1,3 +1,3 @@
 "Version information for fabric_mcp."
 
-__version__ = "0.5.2"
+__version__ = "0.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,9 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "requests>=2.28.0",
+    "httpx>=0.28.1",
     "modelcontextprotocol>=0.1.0",
-    "fastmcp>=2.2.7",
+    "fastmcp>=2.2.10",
     "rich>=14.0.0",
 ]
 
@@ -35,9 +35,9 @@ fabric-mcp = "fabric_mcp.cli:main"
 dev = [
     "hatch>=1.14.1",
     "hatchling>=1.27.0",
-    "pylint>=3.3.6",
+    "pylint>=3.3.7",
     "pytest>=8.3.5",
-    "ruff>=0.5.0",
+    "ruff>=0.11.8",
     "uv>=0.7.2",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -154,7 +154,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.50.0"
+version = "0.51.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -165,9 +165,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/85/4dd9f80da0727c56d7e7f7c627cb724edd9e6df062df6ecc0e90f06e6dbb/anthropic-0.50.0.tar.gz", hash = "sha256:42175ec04ce4ff2fa37cd436710206aadff546ee99d70d974699f59b49adc66f", size = 213021, upload-time = "2025-04-22T23:11:38.459Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/4a/96f99a61ae299f9e5aa3e765d7342d95ab2e2ba5b69a3ffedb00ef779651/anthropic-0.51.0.tar.gz", hash = "sha256:6f824451277992af079554430d5b2c8ff5bc059cc2c968cdc3f06824437da201", size = 219063, upload-time = "2025-05-07T15:39:22.348Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/ae/975f97ad5581a9e187a3717e21d79d6c7ad6be926fee9aa8a15b3d9f8f37/anthropic-0.50.0-py3-none-any.whl", hash = "sha256:defbd79327ca2fa61fd7b9eb2f1627dfb1f69c25d49288c52e167ddb84574f80", size = 245291, upload-time = "2025-04-22T23:11:36.434Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/6e/9637122c5f007103bd5a259f4250bd8f1533dd2473227670fd10a1457b62/anthropic-0.51.0-py3-none-any.whl", hash = "sha256:b8b47d482c9aa1f81b923555cebb687c2730309a20d01be554730c8302e0f62a", size = 263957, upload-time = "2025-05-07T15:39:20.82Z" },
 ]
 
 [[package]]
@@ -545,8 +545,8 @@ name = "fabric-mcp"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
+    { name = "httpx" },
     { name = "modelcontextprotocol" },
-    { name = "requests" },
     { name = "rich" },
 ]
 
@@ -562,9 +562,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=2.2.7" },
+    { name = "fastmcp", specifier = ">=2.2.10" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "modelcontextprotocol", specifier = ">=0.1.0" },
-    { name = "requests", specifier = ">=2.28.0" },
     { name = "rich", specifier = ">=14.0.0" },
 ]
 
@@ -572,9 +572,9 @@ requires-dist = [
 dev = [
     { name = "hatch", specifier = ">=1.14.1" },
     { name = "hatchling", specifier = ">=1.27.0" },
-    { name = "pylint", specifier = ">=3.3.6" },
+    { name = "pylint", specifier = ">=3.3.7" },
     { name = "pytest", specifier = ">=8.3.5" },
-    { name = "ruff", specifier = ">=0.5.0" },
+    { name = "ruff", specifier = ">=0.11.8" },
     { name = "uv", specifier = ">=0.7.2" },
 ]
 


### PR DESCRIPTION
## Summary

This pull request primarily refactors the `FabricApiClient` to use `httpx` instead of `requests` for handling HTTP requests. This change aims to modernize our HTTP client, leverage `httpx`'s features such as improved connection pooling and built-in retry mechanisms, and align with current best practices.

Additionally, this PR includes:
- Updates to several development and runtime dependencies.
- A version bump for the `fabric_mcp` package.
- Enhancements to the `contributing.md` documentation with details about our CI/CD pipeline rulesets.
- Minor updates to the `cspell.json` dictionary.

## Files Changed

-   **`cspell.json`**:
    -   Added `keepalive` and `ksylvan` to the spell check dictionary to prevent false positives.
-   **`docs/contributing.md`**:
    -   Added a new section "Details about the CI/CD Pipeline" which outlines the GitHub rulesets for "Main branch deletion protection" and "Merge into Develop". This provides transparency for contributors on branch protection and merge requirements.
-   **`fabric_mcp/__about__.py`**:
    -   Incremented the package version from `0.5.2` to `0.6.0` to reflect the significant changes, particularly the HTTP client migration.
-   **`fabric_mcp/api_client.py`**:
    -   Replaced `requests` library with `httpx`.
    -   Updated client initialization, request methods, response handling, and exception management to align with `httpx`'s API.
    -   Implemented a `close()` method to properly manage the lifecycle of the `httpx.Client`.
    -   Updated the example usage script to reflect these changes.
-   **`pyproject.toml`**:
    -   Replaced `requests>=2.28.0` with `httpx>=0.28.1`.
    -   Updated versions for `fastmcp` (to `>=2.2.10`), `pylint` (to `>=3.3.7`), and `ruff` (to `>=0.11.8`).
-   **`uv.lock`**:
    -   Updated the lock file to reflect the changes in dependencies specified in `pyproject.toml`. This includes changes to `anthropic` (dependency of a dependency, likely) and the direct changes made.

## Code Changes

### `fabric_mcp/api_client.py`

The most significant changes are in this file, where `requests` has been entirely replaced by `httpx`.

**1. Initialization and Configuration:**
   - The `requests.Session` and its adapter-based retry mechanism:
     ```python
     # Old (requests)
     self.session = requests.Session()
     self.session.headers.update(
         {"User-Agent": f"FabricMCPClient/v{fabric_mcp_version}"}
     )
     if self.api_key:
         self.session.headers.update({self.FABRIC_API_HEADER: f"{self.api_key}"})

     retry_strategy = Retry(
         total=3,
         backoff_factor=0.3,
         status_forcelist=[500, 502, 503, 504],
         allowed_methods=["HEAD", "GET", "OPTIONS", "POST", "PUT", "DELETE"],
     )
     adapter = HTTPAdapter(max_retries=retry_strategy)
     self.session.mount("http://", adapter)
     self.session.mount("https://", adapter)
     ```
   - Is now replaced by `httpx.Client` with direct transport configuration for retries and limits:
     ```python
     # New (httpx)
     limits = httpx.Limits(max_connections=100, max_keepalive_connections=20)
     transport = httpx.HTTPTransport(retries=3) # Retries for common transient errors

     headers = {"User-Agent": f"FabricMCPClient/v{fabric_mcp_version}"}
     if self.api_key:
         headers[self.FABRIC_API_HEADER] = f"{self.api_key}"

     self.client = httpx.Client(
         base_url=self.base_url,
         headers=headers,
         timeout=self.timeout,
         limits=limits,
         transport=transport,
     )
     ```
     Note: The `httpx` retry mechanism is simpler to configure via `HTTPTransport`. The `status_forcelist` and `allowed_methods` from `urllib3.Retry` are handled by `httpx`'s default retry behavior for transient network errors and specific status codes (500, 502, 503, 504).

**2. Request Execution (`_request` method):**
   - The internal `_request` method now uses `self.client.request(...)` and returns an `httpx.Response`.
   - URL construction is simplified as `httpx.Client` handles the `base_url`.
   - Exception handling is updated from `requests.exceptions.RequestException` to `httpx.RequestError` (for network/request issues) and `httpx.HTTPStatusError` (for 4xx/5xx responses).
     ```python
     # Old (requests)
     # response = self.session.request(...)
     # response.raise_for_status()
     # except requests.exceptions.RequestException as e:
     #     logger.error("API request failed: %s %s - %s", method, url, e)
     #     raise

     # New (httpx)
     response = self.client.request(
         method=method,
         url=endpoint, # No need to prepend base_url
         # ...
     )
     response.raise_for_status() # Now raises httpx.HTTPStatusError
     # ...
     except httpx.RequestError as e: # Catches connection errors, timeouts etc.
         logger.error("API request failed: %s %s - %s", method, endpoint, e)
         raise
     except httpx.HTTPStatusError as e: # Catches 4xx/5xx responses
         logger.error(
             "API request failed with status %s: %s %s - %s",
             e.response.status_code,
             method,
             endpoint,
             e,
         )
         raise
     ```

**3. Public HTTP Methods (`get`, `post`, `put`, `delete`):**
   - Return type hints updated from `requests.Response` to `httpx.Response`.

**4. Client Lifecycle Management:**
   - A new `close()` method has been added to ensure the `httpx.Client` is properly closed and resources are released.
     ```python
     def close(self):
         """Closes the httpx client and releases resources."""
         if hasattr(self, "client"):
             self.client.close()
         logger.info("FabricApiClient closed.")
     ```
   - The example usage in `if __name__ == "__main__":` now includes a `finally` block to call `client.close()`.

### `pyproject.toml`
Dependency changes:
```diff
 dependencies = [
-    "requests>=2.28.0",
+    "httpx>=0.28.1",
     "modelcontextprotocol>=0.1.0",
-    "fastmcp>=2.2.7",
+    "fastmcp>=2.2.10",
     "rich>=14.0.0",
 ]
```
And corresponding updates in the `[project.optional-dependencies]` section for `dev` dependencies.

## Reason for Changes

-   **Modernization & Features**: `httpx` is a modern HTTP client for Python, offering both sync and async APIs (though we are only using sync for now). It provides features like HTTP/2 support, improved connection pooling, and a more straightforward API for common tasks like retries.
-   **Dependency Management**: Keeping dependencies up-to-date is crucial for security, bug fixes, and access to new features.
-   **Improved Developer Experience**: `httpx`'s API can be more intuitive for certain operations, and its built-in retry mechanism simplifies client configuration.
-   **Documentation Clarity**: Adding CI/CD details to `contributing.md` helps contributors understand the development workflow and requirements.

## Impact of Changes

-   **Core HTTP Client**: The fundamental way `FabricApiClient` communicates over HTTP has changed. While the external API of `FabricApiClient` (methods like `get`, `post`) remains largely the same in terms of parameters, the underlying implementation and the type of response object returned are different.
-   **Exception Handling**: Consumers of `FabricApiClient` will need to update their error handling to catch `httpx.RequestError` and `httpx.HTTPStatusError` instead of `requests.exceptions.RequestException`.
-   **Resource Management**: It is now important for users of `FabricApiClient` to call the `client.close()` method when they are done with the client instance to ensure network resources are properly released. This is a common pattern for clients that manage persistent connections.
-   **Performance**: `httpx` can offer performance benefits due to its design and support for modern HTTP features, though this would need to be benchmarked for specific use cases.
-   **Dependency Footprint**: The project now depends on `httpx` and its dependencies instead of `requests`.

## Potential Bugs or Issues

-   **Unhandled `httpx` Exceptions**: While common exceptions are handled, there might be specific `httpx` error scenarios not fully accounted for in existing consumer code. Thorough testing of error paths is recommended.
-   **Retry Behavior Differences**: The default retry behavior of `httpx.HTTPTransport(retries=3)` might differ subtly from the previous `urllib3.Retry` configuration (e.g., specific conditions for retrying, backoff strategy details if not customized). This should be acceptable for most cases but is worth noting.
-   **Resource Leaks if `close()` is not called**: If instances of `FabricApiClient` are created and not explicitly closed (e.g., in long-running applications or scripts), it could lead to resource leaks (sockets, etc.). This is a new responsibility for the client user.
-   **Proxy Configuration**: If any deployments relied on environment variables like `HTTP_PROXY`/`HTTPS_PROXY` with `requests`, their behavior with `httpx` should be verified. `httpx` generally respects these standard environment variables.

## Test Plan

1.  **Unit Tests**: Ensure all existing unit tests for `FabricApiClient` pass after modification to use `httpx` and mock its behavior.
2.  **Integration Tests**:
    -   Run existing integration tests that make live API calls (if any) to ensure they function correctly.
    -   Manually test the example script provided in `fabric_mcp/api_client.py` against a test instance of the Fabric API.
3.  **Error Handling Tests**:
    -   Verify that network errors (e.g., by temporarily disabling network or pointing to an invalid host) are caught as `httpx.RequestError`.
    -   Verify that HTTP error statuses (e.g., 401, 404, 500 from the server) are caught as `httpx.HTTPStatusError` and that the response content can still be accessed if needed (e.g., `e.response.text`).
4.  **Resource Management Test**:
    -   In a test script, create and use multiple instances of `FabricApiClient`, ensuring `close()` is called, and monitor for any resource leakage (though this can be hard to precisely measure without dedicated tools).
5.  **Dependency Check**: Confirm that `uv pip install .` and `uv pip install .[dev]` work correctly and resolve all dependencies.

## Additional Notes

-   Developers using `FabricApiClient` directly will need to update their code to handle the new exception types and to call `client.close()` when appropriate.
-   The move to `httpx` also positions the library well for potential future adoption of asynchronous operations if needed, as `httpx` supports both sync and async paradigms.
