### PR TITLE
doc: fix copy-paste logo link error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <img src="https://github.com/ksylvan/fabric-mcp/blob/main/docs/logo.png?raw=true" alt="fabric-mcp logo" width="150" height="150">
 </div>
 
-**Connect the power of the Fabric AI framework to any Model Context Protocol (MCP) compatible application.**
+Connect the power of the Fabric AI framework to any Model Context Protocol (MCP) compatible application.
 
 This project implements a standalone server that bridges the gap between [Daniel Miessler's Fabric framework][fabricGithubLink] and the [Model Context Protocol (MCP)][MCP]. It allows you to use Fabric's patterns, models, and configurations directly within MCP-enabled environments like IDE extensions or chat interfaces.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 | [![Main Tests][main_tests]][main_tests_link] | [![Main Publish][main_publish]][main_publish_link] |  | [![Develop Tests][develop_tests]][develop_tests_link] | [![Develop Publish][develop_publish]][develop_publish_link] |
 
 <div align="center">
-<img src="https://github.com/ksylvan/pyhatchery/blob/main/docs/logo.png?raw=true" alt="fabric-mcp logo" width="150" height="150">
+<img src="https://github.com/ksylvan/fabric-mcp/blob/main/docs/logo.png?raw=true" alt="fabric-mcp logo" width="150" height="150">
 </div>
 
 **Connect the power of the Fabric AI framework to any Model Context Protocol (MCP) compatible application.**

--- a/fabric_mcp/__about__.py
+++ b/fabric_mcp/__about__.py
@@ -1,3 +1,3 @@
 "Version information for fabric_mcp."
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"


### PR DESCRIPTION
# Fix logo link copy-paste error

## Summary
This pull request updates the `README.md` file to correct the logo image URL and bumps the version of the `fabric_mcp` package from `0.6.2` to `0.6.3`.

## Files Changed
1. `README.md`: The logo image URL was updated to point to the correct location.
2. `fabric_mcp/__about__.py`: The version number was incremented to reflect the changes made.

## Code Changes
### README.md
```markdown
<img src="https://github.com/ksylvan/pyhatchery/blob/main/docs/logo.png?raw=true" alt="fabric-mcp logo" width="150" height="150">
```
was changed to
```markdown
<img src="https://github.com/ksylvan/fabric-mcp/blob/main/docs/logo.png?raw=true" alt="fabric-mcp logo" width="150" height="150">
```
This change corrects the logo image URL to point to the correct repository.

### fabric_mcp/__about__.py
```python
__version__ = "0.6.2"
```
was changed to
```python
__version__ = "0.6.3"
```
This change increments the package version to reflect the updates made.

## Reason for Changes
The changes were made to correct the logo image URL in the `README.md` file and to bump the package version to reflect the updates. The incorrect logo URL was likely due to a copy-paste error or incorrect repository reference.

## Impact of Changes
The changes will improve the accuracy of the `README.md` file by displaying the correct logo and will also reflect the updated version of the package.

## Test Plan
To test these changes, one can simply review the updated `README.md` file to verify that the logo is displayed correctly and check the package version using the appropriate command (e.g., `python -c "import fabric_mcp; print(fabric_mcp.__version__)"`).

## Additional Notes
No additional notes are necessary for this pull request as the changes are straightforward and well-documented.
