### PR TITLE
Add Pre-Commit Hooks and Streamlined Merge Workflow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: no-commit-to-branch
+        args: ['--branch', 'main', '--branch', 'develop']
+
+  # Enforce conventional commit messages
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.2.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]

--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,26 @@
 # Makefile for
 #
 
-.PHONY: help bootstrap test coverage coverage-html coverage-show lint format build clean tag
+.PHONY: _default bootstrap build clean coverage coverage-html coverage-show format help lint merge tag test
 
 COVERAGE_FAIL_UNDER := 90
 PACKAGE_PATH := src/fabric_mcp
 
 VERSION := $(shell uv run hatch version)
 
-help:
-	@echo "Makefile for fabric_mcp (Version $(VERSION))"
-	@echo ""
-	@echo "Usage: make [target]"
-	@echo ""
-	@echo "Targets:"
-	@echo "  bootstrap     Bootstrap the project"
-	@echo "  build         Build the project"
-	@echo "  clean         Clean up the project"
-	@echo "  coverage      Run test coverage"
-	@echo "  coverage-html Run tests and generate an HTML coverage report."
-	@echo "  coverage-show Show the coverage report in the browser."
-	@echo "  format        Format the codebase"
-	@echo "  help          Show this help message"
-	@echo "  lint          Run linters"
-	@echo "  tag           Tag the current git HEAD with the semantic versioning name."
-	@echo "  test          Run tests"
+_default: help
 
 bootstrap:
 	uv sync --dev
+	uv run pre-commit autoupdate
+	uv run pre-commit install
+	uv run pre-commit install --hook-type commit-msg
 
-test: lint
-	uv run pytest -v
+build:
+	uv run hatch build
+
+clean:
+	rm -f ../.venv && rm -rf .venv && rm -rf dist
 
 coverage:
 	uv run pytest --cov=$(PACKAGE_PATH) \
@@ -50,6 +40,28 @@ coverage-show:
 	@open coverage_html/index.html || xdg-open coverage_html/index.html || start coverage_html/index.html
 	@echo "Done."
 
+format:
+	uv run ruff format .
+	uv run isort .
+
+help:
+	@echo "Makefile for fabric_mcp (Version $(VERSION))"
+	@echo ""
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@echo "  bootstrap     Bootstrap the project"
+	@echo "  build         Build the project"
+	@echo "  clean         Clean up the project"
+	@echo "  coverage      Run test coverage"
+	@echo "  coverage-html Run tests and generate an HTML coverage report."
+	@echo "  coverage-show Show the coverage report in the browser."
+	@echo "  format        Format the codebase"
+	@echo "  help          Show this help message"
+	@echo "  lint          Run linters"
+	@echo "  merge         Merge develop into main branch (bypassing pre-commit hooks)"
+	@echo "  tag           Tag the current git HEAD with the semantic versioning name."
+	@echo "  test          Run tests"
 
 lint:
 	uv run ruff format --check .
@@ -57,16 +69,33 @@ lint:
 	uv run pylint --fail-on=W0718 $(PACKAGE_PATH) tests
 	uv run pyright $(PACKAGE_PATH) tests
 
-format:
-	uv run ruff format .
-	uv run isort .
-
-# Target to build the application's source distribution and wheel
-build:
-	uv run hatch build
-
-clean:
-	rm -f ../.venv && rm -rf .venv && rm -rf dist
+merge:
+	@echo "This will merge develop into main and push to origin."
+	@read -p "Are you sure? (y/N): " confirm && [ "$$confirm" = "y" ] || { echo "Merge aborted."; exit 1; }
+	@echo "Merging develop into main..."
+	@current_branch=$$(git rev-parse --abbrev-ref HEAD); \
+	if [ "$$current_branch" != "develop" ]; then \
+		echo "Error: You must be on the develop branch to run this command."; \
+		echo "Current branch: $$current_branch"; \
+		exit 1; \
+	fi
+	@echo "Ensuring develop is up to date..."
+	git pull origin develop
+	@echo "Switching to main..."
+	git checkout main
+	@echo "Pulling latest main..."
+	git pull origin main
+	@echo "Merging develop into main (bypassing pre-commit hooks)..."
+	git merge develop --no-verify
+	@echo "Pushing to main..."
+	git push origin main
+	@echo "Switching back to develop..."
+	git checkout develop
+	@echo "Merge completed successfully!"
 
 tag:
 	git tag v$(VERSION)
+
+test: lint
+	uv run pytest -v
+

--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ Feedback on the [design document][design_doc] is highly welcome! Please open an 
 
 Read the [contribution document here](./docs/contributing.md) and please follow the guidelines for this repository.
 
+Also refer to the [cheat-sheet for contributors](./docs/contributing-cheatsheet.md) which contains a micro-summary of the
+development workflow.
+
 ## License
 
 Copyright (c) 2025, [Kayvan Sylvan](kayvan@sylvan.com) Licensed under the [MIT License](./LICENSE).

--- a/cspell.json
+++ b/cspell.json
@@ -1,5 +1,6 @@
 {
 	"words": [
+		"autoupdate",
 		"autouse",
 		"caplog",
 		"capsys",

--- a/docs/contributing-cheatsheet.md
+++ b/docs/contributing-cheatsheet.md
@@ -1,0 +1,38 @@
+# Contributing to `fabric-mcp` (Micro Summary)
+
+## For Developers
+
+```bash
+# One-time setup (new contributor)
+
+git clone https://github.com/ksylvan/fabric-mcp.git
+cd fabric-mcp
+make bootstrap  # ← Installs deps AND pre-commit hooks automatically
+
+# Daily workflow
+
+git checkout develop
+git checkout -b feature/my-change
+
+# make changes
+
+git commit -m "feat: my changes"  # ← Hooks run, ensure good practices
+git push -u origin feature/my-change
+```
+
+Submit your PR with `develop` as its base. Your change must pass all automated tests and meet coverage targets.
+
+## Release workflow (for maintainers)
+
+After a PR is merged:
+
+```bash
+git checkout develop
+git pull
+make merge  # ← Safe, confirmed merge to main
+```
+
+## For more details
+
+Read the [Contributing guidelines](./contributing.md) and the
+[detailed guide to Contributing](./contributing-detailed.md).

--- a/docs/contributing-detailed.md
+++ b/docs/contributing-detailed.md
@@ -114,6 +114,9 @@ make bootstrap
 
 This command executes `uv sync --dev` which sets up the `.venv` virtual environment and installs all packages defined in `pyproject.toml`. This single command ensures your development environment is correctly configured.
 
+We also install pre-commit hooks at this step to prevent direct commits into `develop` and `main`. All fixes
+and feature work will be done on branches in your fork.
+
 ## Development Workflow
 
 This section describes the common tasks and tools used during the development of `fabric-mcp`.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,8 @@
 # Contributing to `fabric-mcp`
 
-Thank you for your interest in improving `fabric-mcp`, a Model Context Protocol server for Fabric AI. Every contribution matters. This guide outlines how to get started, follow development practices, and submit effective changes.
+Thank you for your interest in improving `fabric-mcp`, a Model Context Protocol
+server for Fabric AI. Every contribution matters. This guide outlines how to
+get started, follow development practices, and submit effective changes.
 
 ## Getting Started
 
@@ -43,7 +45,7 @@ Use `make` to configure the development environment:
 make bootstrap
 ```
 
-This command uses `uv sync --dev` to install all dependencies into `.venv`.
+This command uses `uv sync --dev` to install all dependencies into `.venv`, and also configure pre-commit hooks.
 
 ## Development Workflow
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ fabric-mcp = "fabric_mcp.cli:main"
 dev = [
     "hatch>=1.14.1",
     "hatchling>=1.27.0",
+    "pre-commit>=4.2.0",
     "pylint>=3.3.7",
     "pylint-pytest>=1.1.7",
     "pyright>=1.1.401",
@@ -76,7 +77,7 @@ reportAny = true
 dev-mode-dirs = ["src"]
 
 [tool.hatch.build.targets.wheel]
-packages = ["fabric_mcp"]
+packages = ["src/fabric_mcp"]
 
 [tool.hatch.build.targets.sdist]
 sources = ["src"]

--- a/src/fabric_mcp/__about__.py
+++ b/src/fabric_mcp/__about__.py
@@ -1,3 +1,3 @@
 "Version information for fabric_mcp."
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/uv.lock
+++ b/uv.lock
@@ -29,6 +29,7 @@ dependencies = [
     { name = "propcache" },
     { name = "yarl" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/61/d37b33a074ad867d1ecec9f03183e2b9fee067745cae17e73c264f556d57/aiohttp-3.12.0.tar.gz", hash = "sha256:e3f0a2b4d7fb16c0d584d9b8860f1e46d39f7d93372b25a6f80c10015a7acdab", size = 7762804, upload-time = "2025-05-24T22:33:33.318Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/8c/f2d1c0cb4b859185bb38369180785342ef0ba56328c8cb2a0b7c9ddf8651/aiohttp-3.12.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:38ab87bc3c2f2c3861438e537cbd6732d72b73f2b82ea9ba4b214b6aca170ad9", size = 697333, upload-time = "2025-05-24T22:30:51.888Z" },
     { url = "https://files.pythonhosted.org/packages/6e/d7/65d1de0140b952cc88683cf4f52fe0c29d5c617ee1c5a4b9b40ad43d67c8/aiohttp-3.12.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8862c9b190854c0ff3f5a3f25abee9ed7641aee6eccdc81aed2c3d427623d3dc", size = 469618, upload-time = "2025-05-24T22:30:54.168Z" },
@@ -326,6 +327,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114, upload-time = "2023-08-12T20:38:17.776Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249, upload-time = "2023-08-12T20:38:16.269Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -557,6 +567,7 @@ dependencies = [
 dev = [
     { name = "hatch" },
     { name = "hatchling" },
+    { name = "pre-commit" },
     { name = "pylint" },
     { name = "pylint-pytest" },
     { name = "pyright" },
@@ -581,6 +592,7 @@ requires-dist = [
 dev = [
     { name = "hatch", specifier = ">=1.14.1" },
     { name = "hatchling", specifier = ">=1.27.0" },
+    { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pylint", specifier = ">=3.3.7" },
     { name = "pylint-pytest", specifier = ">=1.1.7" },
     { name = "pyright", specifier = ">=1.1.401" },
@@ -1149,6 +1161,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3a/51/1947bd81d75af87e3bb9e34593a4cf118115a8feb451ce7a69044ef1412e/hyperlink-21.0.0.tar.gz", hash = "sha256:427af957daa58bc909471c6c40f74c5450fa123dd093fc53efd2e91d2705a56b", size = 140743, upload-time = "2021-01-08T05:51:20.972Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6e/aa/8caf6a0a3e62863cbb9dab27135660acba46903b703e224f14f447e57934/hyperlink-21.0.0-py2.py3-none-any.whl", hash = "sha256:e6b14c37ecb73e89c77d78cdb4c2cc8f3fb59a885c5b3f819ff4ed80f25af1b4", size = 74638, upload-time = "2021-01-08T05:51:22.906Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/88/d193a27416618628a5eea64e3223acd800b40749a96ffb322a9b55a49ed1/identify-2.6.12.tar.gz", hash = "sha256:d8de45749f1efb108badef65ee8386f0f7bb19a7f26185f74de6367bffbaf0e6", size = 99254, upload-time = "2025-05-23T20:37:53.3Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/cd/18f8da995b658420625f7ef13f037be53ae04ec5ad33f9b718240dcfd48c/identify-2.6.12-py2.py3-none-any.whl", hash = "sha256:ad9672d5a72e0d2ff7c5c8809b62dfa60458626352fb0eb7b55e69bdc45334a2", size = 99145, upload-time = "2025-05-23T20:37:51.495Z" },
 ]
 
 [[package]]
@@ -1738,6 +1759,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ce/5b/2e9890700b7b55a370edbfbe5948eae780d48af9b46ad06ea2e7970576f4/posthog-4.2.0.tar.gz", hash = "sha256:c4abc95de03294be005b3b7e8735e9d7abab88583da26262112bacce64b0c3b5", size = 80727, upload-time = "2025-05-23T23:23:55.943Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/16/7b6c5844acee2d343d463ee0e3143cd8c7c48a6c0d079a2f7daf0c80b95c/posthog-4.2.0-py2.py3-none-any.whl", hash = "sha256:60c7066caac43e43e326e9196d8c1aadeafc8b0be9e5c108446e352711fa456b", size = 96692, upload-time = "2025-05-23T23:23:54.384Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/39/679ca9b26c7bb2999ff122d50faa301e49af82ca9c066ec061cfbc0c6784/pre_commit-4.2.0.tar.gz", hash = "sha256:601283b9757afd87d40c4c4a9b2b5de9637a8ea02eaff7adc2d0fb4e04841146", size = 193424, upload-time = "2025-03-18T21:35:20.987Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/74/a88bf1b1efeae488a0c0b7bdf71429c313722d1fc0f377537fbe554e6180/pre_commit-4.2.0-py2.py3-none-any.whl", hash = "sha256:a009ca7205f1eb497d10b845e52c838a98b6cdd2102a6c8e4540e94ee75c58bd", size = 220707, upload-time = "2025-03-18T21:35:19.343Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Add Pre-Commit Hooks and Streamlined Merge Workflow

## Summary

This PR introduces pre-commit hooks to enforce code quality standards and adds a streamlined workflow for merging from develop to main. The changes include setting up conventional commit message validation, branch protection, and improved developer documentation.

## Files Changed

- **`.pre-commit-config.yaml`** (Added): New pre-commit configuration file that sets up hooks to prevent direct commits to protected branches (main/develop) and enforce conventional commit message format.

- **`Makefile`** (Modified): Enhanced with pre-commit integration in bootstrap process, added new `merge` target for safe develop-to-main merges, and reorganized targets alphabetically.

- **`README.md`** (Modified): Added reference to the new contributor cheat-sheet document.

- **`cspell.json`** (Modified): Added "autoupdate" to the spell checker dictionary.

- **`docs/contributing-cheatsheet.md`** (Added): New micro-summary document providing quick reference for contributors and maintainers.

- **`docs/contributing-detailed.md`** (Modified): Updated to mention pre-commit hooks installation during bootstrap.

- **`docs/contributing.md`** (Modified): Updated bootstrap description to include pre-commit hooks setup.

- **`pyproject.toml`** (Modified): Added pre-commit as a development dependency and fixed wheel package path.

- **`src/fabric_mcp/__about__.py`** (Modified): Version bump from 0.7.0 to 0.8.0.

- **`uv.lock`** (Modified): Updated with new dependencies (cfgv, identify, pre-commit) and their transitive dependencies.

## Code Changes

### Pre-commit Configuration
```yaml
repos:
  - repo: https://github.com/pre-commit/pre-commit-hooks
    rev: v5.0.0
    hooks:
      - id: no-commit-to-branch
        args: ['--branch', 'main', '--branch', 'develop']

  - repo: https://github.com/compilerla/conventional-pre-commit
    rev: v4.2.0
    hooks:
      - id: conventional-pre-commit
        stages: [commit-msg]
```

### Makefile Bootstrap Enhancement
```makefile
bootstrap:
	uv sync --dev
	uv run pre-commit autoupdate
	uv run pre-commit install
	uv run pre-commit install --hook-type commit-msg
```

### Safe Merge Target
```makefile
merge:
	@echo "This will merge develop into main and push to origin."
	@read -p "Are you sure? (y/N): " confirm && [ "$$confirm" = "y" ] || { echo "Merge aborted."; exit 1; }
	# ... (validation and merge logic)
```

## Reason for Changes

1. **Branch Protection**: Prevent accidental commits directly to main and develop branches, enforcing the PR-based workflow.

2. **Commit Message Standards**: Enforce conventional commit format (feat:, fix:, docs:, etc.) to maintain a clean and semantic git history.

3. **Streamlined Release Process**: The new `make merge` command provides a safe, confirmed way for maintainers to merge develop into main while bypassing pre-commit hooks (necessary for merge commits).

4. **Improved Developer Experience**: The cheat-sheet provides quick reference for common workflows without needing to read the full documentation.

## Impact of Changes

- **Development Workflow**: All contributors will now have pre-commit hooks automatically installed during bootstrap, preventing common mistakes like direct commits to protected branches.

- **Code Quality**: Conventional commit messages will make the git history more readable and enable potential automation of changelogs.

- **Release Process**: Maintainers have a safer, more controlled way to perform releases with the new merge command.

- **Documentation**: New contributors can get started faster with the cheat-sheet reference.

## Test Plan

1. Run `make bootstrap` on a fresh clone to verify pre-commit hooks are installed correctly.
2. Attempt to commit directly to main/develop branches - should be blocked by pre-commit.
3. Test commit messages without conventional format - should be rejected.
4. Test the `make merge` command flow (on a test repository).
5. Verify all existing tests pass with `make test`.

## Additional Notes

- The version bump to 0.8.0 reflects the addition of significant developer tooling improvements.
- The wheel package path was corrected from `["fabric_mcp"]` to `["src/fabric_mcp"]` to properly include the source directory structure.
- Pre-commit hooks can be temporarily bypassed with `git commit --no-verify` if absolutely necessary, though this should be avoided.