### PR TITLE
chore: update documentation links and fastmcp version to 2.5.2

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,61 +18,62 @@ Details the command-line interface (CLI) design, Model Context Protocol (MCP) to
 
 ## Project Epics
 
-### [Epic 1: Foundational Server Setup & Basic Operations](./epic-1.md)
+### [Epic 1: Foundational Server Setup & Basic Operations](./PRD/epic-overview/epic-1-foundational-server-setup-basic-operations.md)
 
 Details the work to establish a runnable Fabric MCP server with essential CLI capabilities, basic MCP communication, connectivity to Fabric, configuration handling, packaging, and support for all transport layers.
 
-### [Epic 2: Fabric Pattern Discovery & Introspection](./epic-2.md)
+### [Epic 2: Fabric Pattern Discovery & Introspection](./PRD/epic-overview/epic-2-fabric-pattern-discovery-introspection.md)
 
 Covers enabling MCP clients to dynamically discover available Fabric patterns and retrieve detailed information like system prompts and metadata.
 
-### [Epic 3: Core Fabric Pattern Execution with Strategy & Parameter Control](./epic-3.md)
+### [Epic 3: Core Fabric Pattern Execution with Strategy & Parameter Control](./PRD/epic-overview/epic-3-core-fabric-pattern-execution-with-strategy-parameter-control.md)
 
 Focuses on allowing MCP clients to execute Fabric patterns, apply strategies, control execution parameters (model, temperature, variables, attachments), and receive output, including streaming.
 
-### [Epic 4: Fabric Environment & Configuration Insights](./epic-4.md)
+### [Epic 4: Fabric Environment & Configuration Insights](./PRD/epic-overview/epic-4-fabric-environment-configuration-insights.md)
 
 Describes providing MCP clients with the ability to list available Fabric models and securely retrieve the current Fabric operational configuration.
 
 ## Architectural Granules (Sharded from Architecture Document)
 
-### [API Reference](./api-reference.md)
+### [API Reference](./architecture/api-reference.md)
 
 Details the external APIs consumed by the server (primarily Fabric REST API) and the internal MCP tools provided by the server, including their endpoints, parameters, and schemas.
 
-### [Component View](./component-view.md)
+### [Component View](./architecture/component-view.md)
 
 Describes the major logical components of the system, their responsibilities, interactions, and the architectural design patterns adopted. Includes component diagrams.
 
-### [Core Workflows & Sequence Diagrams](./sequence-diagrams.md)
+### [Core Workflows & Sequence Diagrams](./architecture/core-workflow-sequence-diagrams.md)
 
 Illustrates key operational and interaction flows within the system using sequence diagrams, such as tool discovery, pattern execution (streaming and non-streaming), and server startup.
 
-### [Data Models](./data-models.md)
+### [Data Models](./architecture/data-models.md)
 
 Explains that the server is stateless and data models are primarily defined by the MCP tool schemas and Fabric API schemas, referencing the API Reference document for details.
 
-### [Environment Variables](./environment-vars.md)
-
-Lists and describes all environment variables used to configure the Fabric MCP Server (e.g., `FABRIC_BASE_URL`, `FABRIC_API_KEY`).
-
-### [Infrastructure and Deployment Overview](./infra-deployment.md)
+### [Infrastructure and Deployment Overview](./architecture/infrastructure-and-deployment-overview.md)
 
 Details how the Fabric MCP Server is intended to be deployed, installed, and operated, including runtime environments and CI/CD.
 
-### [Key Reference Documents (from Architecture)](./key-references.md)
+### [Key Reference Documents (from Architecture)](./PRD/6-key-reference-documents.md)
 
 Lists the primary documents that informed the architecture and are critical for understanding its context. *(Note: This refers to the sharded version of this section from the main architecture document).*
 
-### [Operational Guidelines](./operational-guidelines.md)
+### Operational Guidelines
 
 Consolidates coding standards, the overall testing strategy, error handling strategy, and security best practices for the project.
 
-### [Project Structure (from Architecture)](./project-structure.md)
+- [Coding Standards](./architecture/coding-standards.md)
+- [Testing Strategy](./architecture/overall-testing-strategy.md)
+- [Error Handling Strategy](./architecture/error-handling-strategy.md)
+- [Security Best Practices](./architecture/security-best-practices.md)
+
+### [Project Structure (from Architecture)](./architecture/project-structure.md)
 
 Defines the project's folder and file structure, including key directories for source code, tests, and documentation.
 
-### [Technology Stack](./tech-stack.md)
+### [Technology Stack](./architecture/definitive-tech-stack-selections.md)
 
 Provides the definitive list of technology choices for the project, including languages, frameworks, libraries, and development tooling, along with their versions.
 
@@ -90,20 +91,16 @@ Provides an in-depth guide to contributing, covering advanced topics, tool confi
 
 A micro-summary of the development workflow for quick reference.
 
-### [Development Setup Guide](./development_setup.md)
+### [Development Setup Guide](./contributing-cheatsheet.md)
 
 Summarizes the project setup, including Python version, key development tools (`uv`, `ruff`, `pytest`, `hatch`, `pre-commit`, `pnpm` for MCP Inspector), and essential `make` commands.
 
 ## Other
 
-### [Original High-Level Design Document](./design.md)
+### [Original Documents](./source/index.md)
 
-The initial design document that informed the PRD and subsequent planning.
+The initial design document that informed the PRD and subsequent planning, amd the original PRD. Architecture and Design Architecture documents.
 
-### [Product Manager Checklist (Output)](./PM-checklist.md)
+### [PM, PO, and Architect Checklists](./checklists/index.md)
 
-The completed checklist from the PM's review of the PRD.
-
-### [Architect Checklist (Output)](./architect-checklist.md)
-
-The completed checklist from the Architect's validation of the Architecture Document.
+The various checklists for the MVP development.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ keywords = ["fabric", "mcp", "ai", "framework", "server"]
 dependencies = [
     "httpx>=0.28.1",
     "modelcontextprotocol>=0.1.0",
-    "fastmcp>=2.5.1",
+    "fastmcp>=2.5.2",
     "rich>=14.0.0",
     "httpx-retries>=0.4.0",
 ]

--- a/src/fabric_mcp/__about__.py
+++ b/src/fabric_mcp/__about__.py
@@ -1,3 +1,3 @@
 "Version information for fabric_mcp."
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/uv.lock
+++ b/uv.lock
@@ -581,7 +581,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=2.5.1" },
+    { name = "fastmcp", specifier = ">=2.5.2" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "httpx-retries", specifier = ">=0.4.0" },
     { name = "modelcontextprotocol", specifier = ">=0.1.0" },
@@ -606,7 +606,7 @@ dev = [
 
 [[package]]
 name = "fastmcp"
-version = "2.5.1"
+version = "2.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup" },
@@ -618,9 +618,9 @@ dependencies = [
     { name = "typer" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/cc/37ff3a96338234a697df31d2c70b50a1d0f5e20f045d9b7cbba052be36af/fastmcp-2.5.1.tar.gz", hash = "sha256:0d10ec65a362ae4f78bdf3b639faf35b36cc0a1c8f5461a54fac906fe821b84d", size = 1035613, upload-time = "2025-05-24T11:48:27.873Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/cc/d2c0e63d2b34681bef4e077611dae662ea722add13a83dc4ae08b6e0fd23/fastmcp-2.5.2.tar.gz", hash = "sha256:761c92fb54f561136f631d7d98b4920152978f6f0a66a4cef689a7983fd05c8b", size = 1039189, upload-time = "2025-05-29T18:11:33.088Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/4f/e7ec7b63eadcd5b10978dbc472fc3c36de3fc8c91f60ad7642192ed78836/fastmcp-2.5.1-py3-none-any.whl", hash = "sha256:a6fe50693954a6aed89fc6e43f227dcd66e112e3d3a1d633ee22b4f435ee8aed", size = 105789, upload-time = "2025-05-24T11:48:26.371Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/ac/caa94ff747e2136829ac2fea33b9583e086ca5431451751bcb2f773e087f/fastmcp-2.5.2-py3-none-any.whl", hash = "sha256:4ea46ef35c1308b369eff7c8a10e4c9639bed046fd646449c1227ac7c3856d83", size = 107502, upload-time = "2025-05-29T18:11:31.577Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Fix broken documentation links and update fastmcp version to 2.5.2

## Summary

This PR updates documentation links and upgrades the `fastmcp` dependency from version 2.5.1 to 2.5.2, along with a corresponding version bump for the fabric_mcp package from 0.9.0 to 0.9.1.

## Files Changed

### `docs/index.md`
Updated all documentation links to use more specific paths that better reflect the document organization structure. Links now point to their actual locations within subdirectories (PRD, architecture, contributing-cheatsheet, etc.) rather than generic filenames at the root level.

### `pyproject.toml`
Updated the `fastmcp` dependency requirement from `>=2.5.1` to `>=2.5.2`.

### `src/fabric_mcp/__about__.py`
Bumped the package version from `0.9.0` to `0.9.1`.

### `uv.lock`
Updated the lock file to reflect the new `fastmcp` version 2.5.2, including updated hashes and metadata.

## Code Changes

### Documentation Structure Updates
```diff
-### [Epic 1: Foundational Server Setup & Basic Operations](./epic-1.md)
+### [Epic 1: Foundational Server Setup & Basic Operations](./PRD/epic-overview/epic-1-foundational-server-setup-basic-operations.md)
```

The documentation now uses a more organized structure with proper subdirectories:
- Epic documents moved to `PRD/epic-overview/`
- Architecture documents moved to `architecture/`
- Operational guidelines split into individual documents for coding standards, testing strategy, error handling, and security
- Source documents and checklists organized into their own directories

### Dependency Version Update
```diff
-    "fastmcp>=2.5.1",
+    "fastmcp>=2.5.2",
```

### Package Version Bump
```diff
-__version__ = "0.9.0"
+__version__ = "0.9.1"
```

## Reason for Changes

1. **Documentation Organization**: The previous flat link structure was becoming difficult to navigate. The new hierarchical organization makes it easier to find specific documents and understand the project structure.

2. **Dependency Update**: The `fastmcp` library was updated to version 2.5.2, which likely includes bug fixes or minor improvements. Keeping dependencies up-to-date ensures we benefit from the latest fixes and improvements.

3. **Version Bump**: Following semantic versioning, the patch version was incremented to reflect the dependency update and documentation improvements.

## Impact of Changes

- **Improved Documentation Navigation**: Users and contributors will find it easier to locate specific documentation based on its category (PRD, architecture, contributing guides, etc.).
- **Better Maintainability**: The organized structure makes it easier to add new documentation without cluttering the root directory.
- **Potential Bug Fixes**: The `fastmcp` update may include fixes or improvements that enhance the stability of the fabric_mcp server.
- **No Breaking Changes**: These are all backward-compatible changes that don't affect the API or functionality.

## Test Plan

1. Verify all documentation links are working correctly and point to the right files
2. Run the existing test suite to ensure the `fastmcp` update doesn't introduce any regressions
3. Test basic server functionality to confirm the dependency update works as expected
4. Verify the package builds and installs correctly with the new version number

## Additional Notes

- The lock file shows that `fastmcp` 2.5.2 includes approximately 3.5KB more content than 2.5.1, suggesting some additions or improvements
- The documentation reorganization appears to follow a logical structure that separates concerns (PRD, architecture, contributing guidelines)
- This change assumes that all the referenced documentation files exist at their new locations
