### PR TITLE
Align MCP path with standard conventions, simplify API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ PACKAGE_PATH := src/fabric_mcp
 # The node package manager could be npm, but why? pnpm is faster and more efficient
 # This is only needed if you are using the fastmcp dev server.
 NPM_PACKAGER := pnpm
+NPX := $(NPM_PACKAGER) dlx
 STDIO_SERVER_SRC_FOR_MCP_INSPECTOR := $(PACKAGE_PATH)/server_stdio.py
 
 VERSION := $(shell uv run hatch version)
@@ -71,6 +72,7 @@ help:
 	@echo "  help          Show this help message"
 	@echo "  lint          Run linters"
 	@echo "  merge         Merge develop into main branch (bypassing pre-commit hooks)"
+	@echo "  mcp-inspector Start the MCP inspector server"
 	@echo "  tag           Tag the current git HEAD with the semantic versioning name."
 	@echo "  test          Run tests"
 
@@ -104,6 +106,14 @@ merge:
 	@echo "Switching back to develop..."
 	git checkout develop
 	@echo "Merge completed successfully!"
+
+mcp-inspector:
+	@echo "Starting MCP inspector server..."
+	@echo "Ensure you have the @modelcontextprotocol/inspector package installed."
+	@echo "If not, run 'make dev' to install it."
+	@echo "Start fabric-mcp in a different terminal window with the http or sse transport."
+	@echo ""
+	$(NPX) @modelcontextprotocol/inspector
 
 tag:
 	git tag v$(VERSION)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Imagine seamlessly using Fabric's specialized prompts for code explanation, refa
     - [Installation From Source (for developers)](#installation-from-source-for-developers)
     - [Installation From PyPI (for users)](#installation-from-pypi-for-users)
   - [Configuration (Environment Variables)](#configuration-environment-variables)
+    - [Transport Options](#transport-options)
   - [Contributing](#contributing)
   - [License](#license)
 
@@ -159,7 +160,7 @@ fabric-mcp --stdio
 fabric-mcp --http-streamable
 
 # Custom host/port for HTTP transport
-fabric-mcp --http-streamable --host 0.0.0.0 --port 3000 --mcp-path /api/mcp
+fabric-mcp --http-streamable --host 0.0.0.0 --port 3000 --mcp-path /message
 ```
 
 ### Transport Options
@@ -170,7 +171,7 @@ The `fabric-mcp` server supports multiple transport methods:
 - **`--http-streamable`**: HTTP-based transport that runs a full HTTP server for MCP communication
   - `--host`: Server bind address (default: 127.0.0.1)
   - `--port`: Server port (default: 8000)
-  - `--mcp-path`: MCP endpoint path (default: /mcp)
+  - `--mcp-path`: MCP endpoint path (default: /message)
 
 For more details on transport configuration, see the [Infrastructure and Deployment Overview](./docs/architecture/infrastructure-and-deployment-overview.md#transport-configuration).
 

--- a/docs/PRD/epic-overview/epic-4-fabric-environment-configuration-insights.md
+++ b/docs/PRD/epic-overview/epic-4-fabric-environment-configuration-insights.md
@@ -9,7 +9,7 @@
             2. Registered and advertised via `list_tools()` (no params, returns object) per `design.md`.
             3. Uses `FabricApiClient` for GET to Fabric API `/models/names`.
             4. Parses JSON response from Fabric API (expected: list of all models, map of models by vendor).
-            5. MCP success response contains structured JSON (e.g., `{"all_models": [...], "models_by_vendor": {...}}`). Empty lists/objects if none.
+            5. MCP success response contains structured JSON (e.g., `{"models": [...], "vendors": {...}}`). Empty lists/objects if none.
             6. Returns structured MCP error for Fabric API errors or connection failures.
             7. Unit tests: mock `FabricApiClient` for success (models/vendors, empty), API errors.
             8. Integration tests: (vs. live local `fabric --serve`) verify response reflects local Fabric model config; test with no models if possible.

--- a/docs/architecture/api-reference.md
+++ b/docs/architecture/api-reference.md
@@ -256,8 +256,8 @@ The Fabric MCP Server provides the following tools to MCP clients. These tools a
 
             ```json
             {
-              "all_models": ["string"],
-              "models_by_vendor": {
+              "models": ["string"],
+              "vendors": {
                 "vendor_name": ["string"]
               }
             }

--- a/docs/contributing-cheatsheet.md
+++ b/docs/contributing-cheatsheet.md
@@ -30,6 +30,14 @@ make dev
 
 Then browse to <http://127.0.0.1:6274> and Connect.
 
+You can also test the http streaming and sse transports by using:
+
+```bash
+make mcp-inspector
+```
+
+This launches the bare MCP inspector (and does not start `fabric-mcp` with the `stdio` transport)
+
 ## Release workflow (for maintainers)
 
 After a PR is merged:

--- a/docs/contributing-detailed.md
+++ b/docs/contributing-detailed.md
@@ -21,6 +21,8 @@
     - [Running Tests](#running-tests)
     - [Code Coverage](#code-coverage)
     - [Using the MCP Inspector](#using-the-mcp-inspector)
+      - [Option 1: FastMCP Dev Server (Recommended for Development)](#option-1-fastmcp-dev-server-recommended-for-development)
+      - [Option 2: Standalone MCP Inspector](#option-2-standalone-mcp-inspector)
   - [Commit Message Guidelines](#commit-message-guidelines)
     - [Conventional Commits Standard](#conventional-commits-standard)
     - [Importance of Clear Messages](#importance-of-clear-messages)
@@ -174,6 +176,8 @@ The `Makefile` provides convenient shortcuts for common development tasks. Below
 | `make coverage` | Runs tests and reports code coverage, failing if below threshold. | `uv run pytest --cov=fabric_mcp -ra -q --cov-report=term-missing --cov-fail-under=90` |
 | `make coverage-html` | Runs tests and generates an HTML code coverage report. | `uv run pytest --cov=fabric_mcp --cov-report=html:coverage_html --cov-fail-under=90` |
 | `make coverage-show` | Opens the HTML coverage report in the browser. | `open coverage_html/index.html \|\| xdg-open coverage_html/index.html \|\| start coverage_html/index.html` |
+| `make dev` | Starts the FastMCP dev server with MCP inspector for interactive testing. | `pnpm install @modelcontextprotocol/inspector`<br>`uv run fastmcp dev src/fabric_mcp/server_stdio.py` |
+| `make mcp-inspector` | Starts the standalone MCP inspector for connecting to running servers. | `pnpm dlx @modelcontextprotocol/inspector` |
 | `make build` | Builds the package. | `uv run hatch build` |
 | `make clean` | Removes temporary build, test, and environment artifacts. | `rm -rf .venv && rm -rf dist` |
 | `make tag` | Tags the current git HEAD with the semantic version. | `git tag v$(VERSION)` (where VERSION is from `uv run hatch version`) |
@@ -315,8 +319,12 @@ Code coverage analysis helps identify parts of the codebase not exercised by the
 ### Using the MCP Inspector
 
 The MCP Inspector is an interactive developer tool for testing and debugging MCP (Model Context Protocol) servers.
+There are two ways to use the MCP Inspector with `fabric-mcp`:
+
+#### Option 1: FastMCP Dev Server (Recommended for Development)
+
 The FastMCP library provides a CLI tool for running our FastMCP-based servers and accessing the
-MCP inspector.
+MCP inspector in an integrated development environment.
 
 ```bash
 make dev
@@ -330,6 +338,25 @@ uv run fastmcp dev src/fabric_mcp/server_stdio.py
 ```
 
 After running `make dev` you can browse to <http://127.0.0.1:6274> and Connect.
+
+#### Option 2: Standalone MCP Inspector
+
+For more advanced testing scenarios or when you need to connect to a separately running `fabric-mcp` server:
+
+```bash
+make mcp-inspector
+```
+
+This starts the standalone MCP inspector using:
+
+```bash
+pnpm dlx @modelcontextprotocol/inspector
+```
+
+When using this option, you'll need to:
+
+1. Start `fabric-mcp` in a separate terminal with the appropriate transport (http or sse)
+2. Connect to the running server through the inspector interface
 
 See the [FastMCP documentation][fastmcp-dev] about using the MCP inspector
 for more information.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -76,6 +76,8 @@ make test          # Lint and run all tests
 make coverage      # Run tests with coverage enforcement (90%)
 make coverage-html # Generate HTML coverage report
 make coverage-show # Open HTML coverage in browser
+make dev           # Start FastMCP dev server with MCP inspector
+make mcp-inspector # Start standalone MCP inspector
 make build         # Build the project
 make clean         # Remove build/test artifacts
 ```
@@ -191,11 +193,23 @@ Common types:
 
 ## Using the MCP Inspector
 
+There are two ways to use the MCP Inspector:
+
+### Option 1: Using the FastMCP Dev Server (Recommended for Development)
+
 ```bash
 make dev
 ```
 
 Then browse to <http://127.0.0.1:6274> and Connect.
+
+### Option 2: Using the Standalone MCP Inspector
+
+```bash
+make mcp-inspector
+```
+
+This starts the standalone MCP inspector. You'll need to run `fabric-mcp` in a separate terminal with the appropriate transport (http or sse) and connect to it through the inspector interface.
 
 See the [FastMCP documentation][fastmcp-dev] about using the MCP inspector
 for more information.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,34 @@
 
 This document serves as the central catalog for all key documentation related to the Fabric MCP Server project.
 
+- [Fabric MCP Server Documentation Index](#fabric-mcp-server-documentation-index)
+  - [Core Project Documents](#core-project-documents)
+    - [Product Requirements Document (PRD)](#product-requirements-document-prd)
+    - [Architecture Document](#architecture-document)
+    - [Developer Experience (DX) and Operational Experience (OpX) Interaction Specification](#developer-experience-dx-and-operational-experience-opx-interaction-specification)
+  - [Project Epics](#project-epics)
+    - [Epic 1: Foundational Server Setup \& Basic Operations](#epic-1-foundational-server-setup--basic-operations)
+    - [Epic 2: Fabric Pattern Discovery \& Introspection](#epic-2-fabric-pattern-discovery--introspection)
+    - [Epic 3: Core Fabric Pattern Execution with Strategy \& Parameter Control](#epic-3-core-fabric-pattern-execution-with-strategy--parameter-control)
+    - [Epic 4: Fabric Environment \& Configuration Insights](#epic-4-fabric-environment--configuration-insights)
+  - [Architectural Granules (Sharded from Architecture Document)](#architectural-granules-sharded-from-architecture-document)
+    - [API Reference](#api-reference)
+    - [Component View](#component-view)
+    - [Core Workflows \& Sequence Diagrams](#core-workflows--sequence-diagrams)
+    - [Data Models](#data-models)
+    - [Infrastructure and Deployment Overview](#infrastructure-and-deployment-overview)
+    - [Key Reference Documents (from Architecture)](#key-reference-documents-from-architecture)
+    - [Operational Guidelines](#operational-guidelines)
+    - [Project Structure (from Architecture)](#project-structure-from-architecture)
+    - [Technology Stack](#technology-stack)
+  - [Contribution \& Development Setup](#contribution--development-setup)
+    - [Main Contribution Guidelines](#main-contribution-guidelines)
+    - [Detailed Contribution Guide](#detailed-contribution-guide)
+    - [Contributing Cheatsheet](#contributing-cheatsheet)
+  - [Other (Archival Reference Documents) - Potentially Out of Date](#other-archival-reference-documents---potentially-out-of-date)
+    - [Original Documents](#original-documents)
+    - [PM, PO, and Architect Checklists](#pm-po-and-architect-checklists)
+
 ## Core Project Documents
 
 ### [Product Requirements Document (PRD)](./PRD/index.md)
@@ -93,7 +121,7 @@ Provides an in-depth guide to contributing, covering advanced topics, tool confi
 
 A micro-summary of the development workflow for quick reference.
 
-## Other
+## Other (Archival Reference Documents) - Potentially Out of Date
 
 ### [Original Documents](./source/index.md)
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,6 +1,10 @@
 # Fabric MCP Server Documentation Index
 
-This index provides an overview of the original key documentation files for the Fabric MCP Server project, which integrates Daniel Miessler's Fabric AI framework with the Model Context Protocol (MCP).
+This index provides an overview of the original key documentation files for the Fabric MCP Server project,
+which integrates Daniel Miessler's Fabric AI framework with the Model Context Protocol (MCP).
+
+NOTE: These documents are here for archival purposes ONLY and should not be regarded
+as the source of truth about the current state. Please refer to the other documentation
 
 ## Core Documentation Files
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,12 +42,12 @@ dev = [
     "pylint>=3.3.7",
     "pylint-pytest>=1.1.8",
     "pyright>=1.1.401",
-    "pytest>=8.3.5",
+    "pytest>=8.4.0",
     "pytest-asyncio>=1.0.0",
     "pytest-cov>=6.1.1",
     "pytest-mock>=3.14.1",
     "ruff>=0.11.12",
-    "uv>=0.7.9",
+    "uv>=0.7.11",
 ]
 
 [tool.pytest.ini_options]

--- a/src/fabric_mcp/__about__.py
+++ b/src/fabric_mcp/__about__.py
@@ -1,3 +1,3 @@
 "Version information for fabric_mcp."
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"

--- a/src/fabric_mcp/cli.py
+++ b/src/fabric_mcp/cli.py
@@ -69,7 +69,7 @@ def validate_server_options(
 )
 @click.option(
     "--mcp-path",
-    default="/mcp",
+    default="/message",
     show_default=True,
     callback=validate_http_options,
     help="MCP endpoint path (HTTP transport only).",

--- a/src/fabric_mcp/cli.py
+++ b/src/fabric_mcp/cli.py
@@ -6,7 +6,7 @@ import click
 
 from fabric_mcp import __version__
 
-from .core import FabricMCP
+from .core import DEFAULT_MCP_HTTP_PATH, DEFAULT_MCP_SSE_PATH, FabricMCP
 from .utils import Log
 
 
@@ -69,14 +69,14 @@ def validate_server_options(
 )
 @click.option(
     "--mcp-path",
-    default="/message",
+    default=DEFAULT_MCP_HTTP_PATH,
     show_default=True,
     callback=validate_http_options,
     help="MCP endpoint path (HTTP transport only).",
 )
 @click.option(
     "--sse-path",
-    default="/sse",
+    default=DEFAULT_MCP_SSE_PATH,
     show_default=True,
     callback=validate_sse_options,
     help="SSE endpoint path (SSE transport only).",

--- a/src/fabric_mcp/core.py
+++ b/src/fabric_mcp/core.py
@@ -105,8 +105,8 @@ class FabricMCP(FastMCP[None]):
             """Retrieve configured Fabric models by vendor."""
             # This is a placeholder for the actual implementation
             return {
-                "all_models": ["gpt-4", "gpt-3.5-turbo", "claude-3-opus"],
-                "models_by_vendor": {
+                "models": ["gpt-4", "gpt-3.5-turbo", "claude-3-opus"],
+                "vendors": {
                     "openai": ["gpt-4", "gpt-3.5-turbo"],
                     "anthropic": ["claude-3-opus"],
                 },
@@ -149,7 +149,7 @@ class FabricMCP(FastMCP[None]):
         self.__tools.append(fabric_get_configuration)
 
     def http_streamable(
-        self, host: str = "127.0.0.1", port: int = 8000, mcp_path: str = "/mcp"
+        self, host: str = "127.0.0.1", port: int = 8000, mcp_path: str = "/message"
     ):
         """Run the MCP server with StreamableHttpTransport."""
         try:

--- a/src/fabric_mcp/core.py
+++ b/src/fabric_mcp/core.py
@@ -10,6 +10,9 @@ from fastmcp import FastMCP
 
 from . import __version__
 
+DEFAULT_MCP_HTTP_PATH = "/message"
+DEFAULT_MCP_SSE_PATH = "/sse"
+
 
 class FabricMCP(FastMCP[None]):
     """Base class for the Model Context Protocol server."""
@@ -149,7 +152,10 @@ class FabricMCP(FastMCP[None]):
         self.__tools.append(fabric_get_configuration)
 
     def http_streamable(
-        self, host: str = "127.0.0.1", port: int = 8000, mcp_path: str = "/message"
+        self,
+        host: str = "127.0.0.1",
+        port: int = 8000,
+        mcp_path: str = DEFAULT_MCP_HTTP_PATH,
     ):
         """Run the MCP server with StreamableHttpTransport."""
         try:
@@ -161,7 +167,12 @@ class FabricMCP(FastMCP[None]):
             self.logger.debug("Exception details: %s: %s", type(e).__name__, e)
             self.logger.info("Server stopped by user.")
 
-    def sse(self, host: str = "127.0.0.1", port: int = 8000, path: str = "/sse"):
+    def sse(
+        self,
+        host: str = "127.0.0.1",
+        port: int = 8000,
+        path: str = DEFAULT_MCP_SSE_PATH,
+    ):
         """Run the MCP server with SSE transport."""
         try:
             self.mcp.run(transport="sse", host=host, port=port, path=path)

--- a/tests/integration/test_http_streamable_transport.py
+++ b/tests/integration/test_http_streamable_transport.py
@@ -33,7 +33,7 @@ class TestHTTPStreamableTransport:
         return {
             "host": "127.0.0.1",
             "port": find_free_port(),
-            "mcp_path": "/mcp",
+            "mcp_path": "/message",
         }
 
     @pytest.mark.asyncio

--- a/tests/shared/transport_test_utils.py
+++ b/tests/shared/transport_test_utils.py
@@ -10,6 +10,8 @@ from typing import Any
 
 import httpx
 
+from fabric_mcp.core import DEFAULT_MCP_HTTP_PATH, DEFAULT_MCP_SSE_PATH
+
 # Type aliases for better readability
 ServerConfig = dict[str, Any]
 
@@ -45,9 +47,9 @@ async def run_server(
 
     # Add transport-specific arguments
     if transport_type == "http":
-        cmd_args.extend(["--mcp-path", config.get("mcp_path", "/message")])
+        cmd_args.extend(["--mcp-path", config.get("mcp_path", DEFAULT_MCP_HTTP_PATH)])
     elif transport_type == "sse":
-        cmd_args.extend(["--sse-path", config.get("sse_path", "/sse")])
+        cmd_args.extend(["--sse-path", config.get("sse_path", DEFAULT_MCP_SSE_PATH)])
 
     # Start server as subprocess for proper isolation
     with subprocess.Popen(

--- a/tests/shared/transport_test_utils.py
+++ b/tests/shared/transport_test_utils.py
@@ -45,7 +45,7 @@ async def run_server(
 
     # Add transport-specific arguments
     if transport_type == "http":
-        cmd_args.extend(["--mcp-path", config.get("mcp_path", "/mcp")])
+        cmd_args.extend(["--mcp-path", config.get("mcp_path", "/message")])
     elif transport_type == "sse":
         cmd_args.extend(["--sse-path", config.get("sse_path", "/sse")])
 

--- a/tests/unit/test_cli_additional.py
+++ b/tests/unit/test_cli_additional.py
@@ -240,7 +240,7 @@ class TestCLIMain:
 
         # Verify http_streamable() was called with defaults
         mock_server.http_streamable.assert_called_once_with(
-            host="127.0.0.1", port=8000, mcp_path="/mcp"
+            host="127.0.0.1", port=8000, mcp_path="/message"
         )
 
     @patch("fabric_mcp.cli.FabricMCP")

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -139,8 +139,8 @@ def test_tool_registration_coverage():
     fabric_list_models = tools[3]
     result = fabric_list_models()
     assert isinstance(result, dict)
-    assert "all_models" in result
-    assert "models_by_vendor" in result
+    assert "models" in result
+    assert "vendors" in result
 
     fabric_list_strategies = tools[4]
     result = fabric_list_strategies()
@@ -167,7 +167,7 @@ def test_http_streamable_method_runs_mcp(server_instance: FabricMCP):
             transport="streamable-http",
             host="127.0.0.1",
             port=8000,
-            path="/mcp",
+            path="/message",
         )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -598,12 +598,12 @@ dev = [
     { name = "pylint", specifier = ">=3.3.7" },
     { name = "pylint-pytest", specifier = ">=1.1.8" },
     { name = "pyright", specifier = ">=1.1.401" },
-    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "pytest-mock", specifier = ">=3.14.1" },
     { name = "ruff", specifier = ">=0.11.12" },
-    { name = "uv", specifier = ">=0.7.9" },
+    { name = "uv", specifier = ">=0.7.11" },
 ]
 
 [[package]]
@@ -2145,17 +2145,18 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.3.5"
+version = "8.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/aa/405082ce2749be5398045152251ac69c0f3578c7077efc53431303af97ce/pytest-8.4.0.tar.gz", hash = "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6", size = 1515232, upload-time = "2025-06-02T17:36:30.03Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload-time = "2025-03-02T12:54:52.069Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/de/afa024cbe022b1b318a3d224125aa24939e99b4ff6f22e0ba639a2eaee47/pytest-8.4.0-py3-none-any.whl", hash = "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e", size = 363797, upload-time = "2025-06-02T17:36:27.859Z" },
 ]
 
 [[package]]
@@ -2590,27 +2591,27 @@ wheels = [
 
 [[package]]
 name = "uv"
-version = "0.7.9"
+version = "0.7.11"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9a/7c/8621d5928111f985196dc75c50a64147b3bad39f36164686f24d45581367/uv-0.7.9.tar.gz", hash = "sha256:baac54e49f3b0d05ee83f534fdcb27b91d2923c585bf349a1532ca25d62c216f", size = 3272882, upload-time = "2025-05-30T19:54:33.003Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/1e/c14906fb512f835c0b3876de7c05d2e43b12f7c74b5b632971bb393b67ea/uv-0.7.11.tar.gz", hash = "sha256:33daeb9f1e5f49f1f192815c580beb996fd3be131821af2e887af4ec575c2a4f", size = 3295412, upload-time = "2025-06-04T20:07:09.287Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/7a/e4d12029e16f30279ef48f387545f8f3974dc3c4c9d8ef59c381ae7e6a7d/uv-0.7.9-py3-none-linux_armv6l.whl", hash = "sha256:0f8c53d411f95cec2fa19471c23b41ec456fc0d5f2efca96480d94e0c34026c2", size = 16746809, upload-time = "2025-05-30T19:53:35.447Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/85/8df3ca683e1a260117efa31373e91e1c03a4862b7add865662f60a967fdf/uv-0.7.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:85c1a63669e49b825923fc876b7467cc3c20d4aa010f522c0ac8b0f30ce2b18e", size = 16821006, upload-time = "2025-05-30T19:53:40.102Z" },
-    { url = "https://files.pythonhosted.org/packages/77/d4/c40502ec8f5575798b7ec13ac38c0d5ded84cc32129c1d74a47f8cb7bc0a/uv-0.7.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:aa10c61668f94515acf93f31dbb8de41b1f2e7a9c41db828f2448cef786498ff", size = 15600148, upload-time = "2025-05-30T19:53:43.513Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/dd/4deec6d5b556f4033d6bcc35d6aad70c08acea3f5da749cb34112dced5da/uv-0.7.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:9de67ca9ea97db71e5697c1320508e25679fb68d4ee2cea27bbeac499a6bad56", size = 16038119, upload-time = "2025-05-30T19:53:46.504Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/c5/2c23763e18566a9a7767738714791203cc97a7530979f61e0fd32d8473a2/uv-0.7.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:13ce63524f88228152edf8a9c1c07cecc07d69a2853b32ecc02ac73538aaa5c1", size = 16467257, upload-time = "2025-05-30T19:53:49.592Z" },
-    { url = "https://files.pythonhosted.org/packages/da/94/f452d0093f466f9f81a2ede3ea2d48632237b79eb1dc595c7c91be309de5/uv-0.7.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3453b7bb65eaea87c9129e27bff701007a8bd1a563249982a1ede7ec4357ced6", size = 17170719, upload-time = "2025-05-30T19:53:52.828Z" },
-    { url = "https://files.pythonhosted.org/packages/69/bf/e15ef77520e9bbf00d29a3b639dfaf4fe63996863d6db00c53eba19535c7/uv-0.7.9-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:d7b1e36a8b39600d0f0333bf50c966e83beeaaee1a38380ccb0f16ab45f351c3", size = 18052903, upload-time = "2025-05-30T19:53:56.237Z" },
-    { url = "https://files.pythonhosted.org/packages/32/9f/ebf3f9910121ef037c0fe9e7e7fb5f1c25b77d41a65a029d5cbcd85cc886/uv-0.7.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ab412ed3d415f07192805788669c8a89755086cdd6fe9f021e1ba21781728031", size = 17771828, upload-time = "2025-05-30T19:53:59.561Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/6c/82b4cd471432e721c239ddde2ebee2e674238f3bd88e279e6c71f3cbc775/uv-0.7.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cbeb229ee86f69913f5f9236ff1b8ccbae212f559d7f029f8432fa8d9abcc7e0", size = 17886161, upload-time = "2025-05-30T19:54:02.865Z" },
-    { url = "https://files.pythonhosted.org/packages/63/e2/922d2eed25647b50a7257a7bfea10c36d9ff910d1451f9a1ba5e31766f41/uv-0.7.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1d654a14d632ecb078969ae7252d89dd98c89205df567a1eff18b5f078a6d00", size = 17442630, upload-time = "2025-05-30T19:54:06.519Z" },
-    { url = "https://files.pythonhosted.org/packages/96/b8/45a5598cc8d466bb1669ccf0fc4f556719babfdb7a1983edc24967cb3845/uv-0.7.9-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:f5f47e93a5f948f431ca55d765af6e818c925500807539b976bfda7f94369aa9", size = 16299207, upload-time = "2025-05-30T19:54:09.713Z" },
-    { url = "https://files.pythonhosted.org/packages/14/35/7e70639cd175f340138c88290c819214a496dfc52461f30f71e51e776293/uv-0.7.9-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:267fe25ad3adf024e13617be9fc99bedebf96bf726c6140e48d856e844f21af4", size = 16427594, upload-time = "2025-05-30T19:54:13.318Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/f6/90fe538370bc60509cca942b703bca06c06c160ec09816ea6946882278d1/uv-0.7.9-py3-none-musllinux_1_1_i686.whl", hash = "sha256:473d3c6ee07588cff8319079d9225fb393ed177d8d57186fce0d7c1aebff79c0", size = 16751451, upload-time = "2025-05-30T19:54:16.833Z" },
-    { url = "https://files.pythonhosted.org/packages/09/cb/c099aba21fb22e50713b42e874075a5b60c6b4d141cc3868ae22f505baa7/uv-0.7.9-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:19792c88058894c10f0370a5e5492bb4a7e6302c439fed9882e73ba2e4b231ef", size = 17594496, upload-time = "2025-05-30T19:54:20.383Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/2e/e35b2c5669533075987e1d74da45af891890ae5faee031f90997ed81cada/uv-0.7.9-py3-none-win32.whl", hash = "sha256:298e9b3c65742edcb3097c2cf3f62ec847df174a7c62c85fe139dddaa1b9ab65", size = 17121149, upload-time = "2025-05-30T19:54:23.608Z" },
-    { url = "https://files.pythonhosted.org/packages/33/8e/d10425711156d0d5d9a28299950acb3ab4a3987b3150a3c871ac95ce2fdd/uv-0.7.9-py3-none-win_amd64.whl", hash = "sha256:82d76ea988ff1347158c6de46a571b1db7d344219e452bd7b3339c21ec37cfd8", size = 18622895, upload-time = "2025-05-30T19:54:27.427Z" },
-    { url = "https://files.pythonhosted.org/packages/72/77/cac29a8fb608b5613b7a0863ec6bd7c2517f3a80b94c419e9d890c12257e/uv-0.7.9-py3-none-win_arm64.whl", hash = "sha256:4d419bcc3138fd787ce77305f1a09e2a984766e0804c6e5a2b54adfa55d2439a", size = 17316542, upload-time = "2025-05-30T19:54:30.697Z" },
+    { url = "https://files.pythonhosted.org/packages/97/29/215c9d939c24f3948d4140ee864d0441c25ceb222a911b58ed3503c02f1a/uv-0.7.11-py3-none-linux_armv6l.whl", hash = "sha256:1950db80e7b5e1549029514cb006b37df1af7418c788acb57c1d46c0f1e8f310", size = 16993485, upload-time = "2025-06-04T20:06:05.796Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ca/41070b1353897ca7c3e62d6922734ced89a3e17ab6b729556b9da1bfbe1d/uv-0.7.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b2e39c2d93a779739b937402bc1f57fdfb5c9514acdcc71215af07d6de8422f3", size = 17074005, upload-time = "2025-06-04T20:06:10.058Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/75/21691f637860f3d013ffc86d76edf2362039df8371f73d379cce7679f324/uv-0.7.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fa506c6492f3993756de785c01a7f2d9615b9c7ccfd8ac56c5b8b08b2db74768", size = 15795126, upload-time = "2025-06-04T20:06:13.847Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/55/319cec0aa5b938e03c6ea712020884488c1bb29f40c5634a8725bc97aca0/uv-0.7.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:b2321cafda2d411287f4fb4ef2e6a997c55101355c79088648ef54743f388874", size = 16312624, upload-time = "2025-06-04T20:06:17.172Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/6c/71d3f9beb8202a1ccfa52bf4dcb16d453565a09e8131397197d412952d35/uv-0.7.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a7ef8dc76a1aa113667543ad79b37ed995f8dd518109e59f4c6952e987a45e43", size = 16732197, upload-time = "2025-06-04T20:06:20.581Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e5/8cd5bff004e2ad7a7551ff87e3aecbacc01e2c120acf87417e41bb587f75/uv-0.7.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2d1115f09cf9feb60a25d0f03558393defa8f6c8118d01649e2bf05a783cc529", size = 17547285, upload-time = "2025-06-04T20:06:26.606Z" },
+    { url = "https://files.pythonhosted.org/packages/57/a9/e3db9f12148e70a35c0ade2cd6670b8e2475883cac097407beba88cad5a6/uv-0.7.11-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f82490ddeb4c0e074f49f5d40c5e2ff863db13e8d3ea894401137f01177f5a65", size = 18380109, upload-time = "2025-06-04T20:06:30.632Z" },
+    { url = "https://files.pythonhosted.org/packages/14/70/a94fbbe854daf21c70794675593c9845efd0cd0902c58168cd4bee42daab/uv-0.7.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:692ed1bf85b05e03d1ec6bc5e362e879a907ac8c539cb1ed31a34dd520c392ba", size = 18069868, upload-time = "2025-06-04T20:06:33.803Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b9/1ece3e01d0f472dce5381920bb7af3a2ba9bef8f1af0ea33ec57df908d28/uv-0.7.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fa3bb9394a96d315d60cd2453a7d17d891693e14f31840bff2cdc96b6552c48f", size = 18183116, upload-time = "2025-06-04T20:06:37.081Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/fc/5ef7d73f3944fbf4ce8884757ec05ccb536115b86b2af1c1bcf32d862f61/uv-0.7.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a4103201781d268e9d46c6e6d93b8d983ee9ec9dbe4c92d3f8181c909bd1deb9", size = 17719403, upload-time = "2025-06-04T20:06:40.806Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/36/b440a6f28548b4a4847956e2fd74d031222414a00da2cd783b94080019b4/uv-0.7.11-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:622e897701cb84657bf86d353afebde5e682a6f9fd4e7454aac65fcd899dfa7a", size = 16598483, upload-time = "2025-06-04T20:06:44.581Z" },
+    { url = "https://files.pythonhosted.org/packages/84/af/f3539087761ab77a773f47b2688daac3475c92a9a2e314ce0bae483d2961/uv-0.7.11-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:363a8aabb3455fd4a15611c8ee4d76ac1a3d587f60250aee7dd4f777a3e02486", size = 16693339, upload-time = "2025-06-04T20:06:47.727Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d5/a97f6a0b09176e13904a53c2f2e42f64e055cfbfded34e721f60021d070c/uv-0.7.11-py3-none-musllinux_1_1_i686.whl", hash = "sha256:839cce114504b466da8ebee42f661845d8566679e90b9707629e7b9f3021dcd0", size = 17072416, upload-time = "2025-06-04T20:06:50.872Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/21/077454ce18568e56309fbbf41da5d75ded73b4460bb44724111e07a7332a/uv-0.7.11-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:a4db2ee6121ad47546d34afefd35d83fdfb41bf03bf03f7c633cb1296411725f", size = 17867858, upload-time = "2025-06-04T20:06:54.646Z" },
+    { url = "https://files.pythonhosted.org/packages/32/e8/dc3ba65157833e84efff44b9c31f3a73588e1ded579a3e6dc227e5daecfa/uv-0.7.11-py3-none-win32.whl", hash = "sha256:38adcfd3c3d03c97e98498073df004ac190d21538ecf40752fb3f1b439c6fe5e", size = 17319759, upload-time = "2025-06-04T20:06:58.172Z" },
+    { url = "https://files.pythonhosted.org/packages/64/28/891d40646c9244e3e4426f4e1747e2882d8e415cfc76c98887faa19b94e3/uv-0.7.11-py3-none-win_amd64.whl", hash = "sha256:949ae795894e92bc3739e5e52b187457644144791917bafed3d58913d7ac07dc", size = 18839020, upload-time = "2025-06-04T20:07:02.913Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/05/3efe83733e8bed16767cc14accbd88439dad05a169c0d19bde2a106bd5e3/uv-0.7.11-py3-none-win_arm64.whl", hash = "sha256:7cce0fd2a9128b5dce6031ebbd15a9f392ed08f6ef53ccce15d47543a5fac5fe", size = 17559089, upload-time = "2025-06-04T20:07:06.455Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Align MCP path with standard conventions, simplify API

## Summary

This PR updates the MCP endpoint path default from `/mcp` to `/message` to align with standard MCP conventions, adds a standalone MCP inspector command to the Makefile, updates the models API response format to match the Fabric REST API, and includes various dependency updates and documentation improvements.

## Files Changed

### **Makefile**
- Added `NPX` variable for executing packages via pnpm
- Added new `mcp-inspector` target that launches the standalone MCP inspector using `pnpm dlx`
- Updated help text to include the new mcp-inspector command

### **README.md**
- Fixed example command to use `/message` instead of `/api/mcp` for the MCP endpoint path
- Added "Transport Options" section to the table of contents

### **docs/PRD/epic-overview/epic-4-fabric-environment-configuration-insights.md**
- Updated expected JSON response format for models API from `all_models`/`models_by_vendor` to `models`/`vendors`

### **docs/architecture/api-reference.md**
- Updated the API documentation to reflect the new response format for the models tool

### **docs/contributing-cheatsheet.md** and **docs/contributing-detailed.md**
- Added documentation for the new `make mcp-inspector` command
- Explained the difference between using FastMCP dev server vs standalone MCP inspector
- Added detailed instructions for both options

### **docs/contributing.md**
- Added brief documentation for the mcp-inspector make target

### **docs/index.md**
- Marked the "Other" section as "Archival Reference Documents - Potentially Out of Date"

### **docs/source/index.md**
- Added a prominent note that these documents are archival only and not the source of truth

### **pyproject.toml**
- Updated pytest from 8.3.5 to 8.4.0
- Updated uv from 0.7.9 to 0.7.11

### **src/fabric_mcp/__about__.py**
- Version bump from 0.12.0 to 0.12.1

### **src/fabric_mcp/cli.py**
- Changed default `--mcp-path` from `/mcp` to `/message`

### **src/fabric_mcp/core.py**
- Updated the `fabric_list_models` tool response format from `all_models`/`models_by_vendor` to `models`/`vendors`
- Updated default mcp_path parameter in `http_streamable` method

### **Test files** (multiple)
- Updated all test files to use `/message` instead of `/mcp` as the default path
- Updated tests to check for new response format keys (`models`/`vendors`)

### **uv.lock**
- Updated with new dependency versions

## Code Changes

### Key API Response Format Change:
```python
# Before
return {
    "all_models": ["gpt-4", "gpt-3.5-turbo", "claude-3-opus"],
    "models_by_vendor": {
        "openai": ["gpt-4", "gpt-3.5-turbo"],
        "anthropic": ["claude-3-opus"],
    },
}

# After
return {
    "models": ["gpt-4", "gpt-3.5-turbo", "claude-3-opus"],
    "vendors": {
        "openai": ["gpt-4", "gpt-3.5-turbo"],
        "anthropic": ["claude-3-opus"],
    },
}
```

### Default MCP Path Change:
```python
# Changed from "/mcp" to "/message" in multiple places
--mcp-path="/message"  # CLI default
mcp_path: str = "/message"  # Function parameter default
```

## Reason for Changes

1. **MCP Path Standardization**: The change from `/mcp` to `/message` aligns with standard MCP protocol conventions and improves compatibility with MCP clients expecting this endpoint.

2. **API Response Simplification**: The rename from `all_models`/`models_by_vendor` to `models`/`vendors` provides cleaner, more intuitive field names in the API response.

3. **Enhanced Developer Experience**: Adding the standalone MCP inspector option gives developers more flexibility in testing different transport methods (HTTP, SSE) without being tied to the FastMCP dev server.

4. **Documentation Clarity**: Marking archival documents and adding notes helps prevent confusion about which documentation represents the current state of the project.

5. **Dependency Updates**: Keeping dependencies up-to-date ensures we have the latest bug fixes and features.

## Impact of Changes

- **Breaking Change**: The API response format change for the models tool is a breaking change. Clients expecting `all_models` and `models_by_vendor` fields will need to update to use `models` and `vendors`.
- **Configuration Change**: Users with existing configurations specifying `/mcp` as the endpoint will need to update to `/message` or explicitly set `--mcp-path /mcp`.
- **Improved Testing**: Developers can now test HTTP and SSE transports more easily using the standalone inspector.
- **No functional impact**: The core functionality remains unchanged; these are primarily naming and tooling improvements.

## Test Plan

- All existing unit tests have been updated to reflect the new defaults and response formats
- Integration tests verify the new endpoint path works correctly
- Manual testing recommended:
  1. Test with FastMCP dev server: `make dev`
  2. Test with standalone inspector: `make mcp-inspector` + run server with HTTP/SSE transport

## Additional Notes

- The version bump to 0.12.1 indicates this is a patch release with backward-compatible bug fixes and improvements
- The pytest update to 8.4.0 adds pygments as a dependency, which may improve test output formatting
- The update for `/message` fixes an error in understanding and matches the official [Streamable HTTP protocol](https://www.claudemcp.com/blog/mcp-streamable-http)