### PR TITLE
feat: implement `fabric_list_models` MCP tool

### DIFF
--- a/docs/PRD/epic-overview/epic-4-fabric-environment-configuration-insights.md
+++ b/docs/PRD/epic-overview/epic-4-fabric-environment-configuration-insights.md
@@ -13,7 +13,7 @@
             6. Returns structured MCP error for Fabric API errors or connection failures.
             7. Unit tests: mock `FabricApiClient` for success (models/vendors, empty), API errors.
             8. Integration tests: (vs. live local `fabric --serve`) verify response reflects local Fabric model config; test with no models if possible.
-  - **Story 4.3: Implement Secure `fabric_get_configuration` MCP Tool with Targeted Redaction**
+  - **Story 4.2: Implement Secure `fabric_get_configuration` MCP Tool with Targeted Redaction**
     - User Story: As an MCP Client Developer, I want to use the `fabric_get_configuration` tool to retrieve the current operational configuration settings of the connected Fabric instance, **with assurances that sensitive values like API keys are redacted**, so that I can display relevant non-sensitive settings or understand the Fabric environment's setup securely.
     - Acceptance Criteria:
             1. Tool implemented in `src/fabric_mcp/core.py`. Registered and advertised via `list_tools()` (no params, returns map/object) per `design.md`.

--- a/docs/stories/4.1.story.md
+++ b/docs/stories/4.1.story.md
@@ -2,7 +2,7 @@
 
 **Epic:** 4 (Fabric Environment & Configuration Insights)
 
-**Status:** Draft
+**Status:** InProgress
 
 ## Story
 

--- a/src/fabric_mcp/__about__.py
+++ b/src/fabric_mcp/__about__.py
@@ -1,3 +1,3 @@
 "Version information for fabric_mcp."
 
-__version__ = "0.19.0"
+__version__ = "0.20.0"

--- a/tests/shared/fabric_api/server.py
+++ b/tests/shared/fabric_api/server.py
@@ -184,6 +184,30 @@ MOCK_STRATEGIES = [
 # Empty strategies for testing empty response case
 EMPTY_STRATEGIES: list[dict[str, str]] = []
 
+# Mock models data that mimics real Fabric API responses
+MOCK_MODELS = {
+    "models": [
+        "gpt-4o",
+        "gpt-3.5-turbo",
+        "claude-3-opus",
+        "claude-3-sonnet",
+        "claude-3-haiku",
+        "llama2",
+        "mixtral",
+    ],
+    "vendors": {
+        "openai": ["gpt-4o", "gpt-3.5-turbo"],
+        "anthropic": ["claude-3-opus", "claude-3-sonnet", "claude-3-haiku"],
+        "ollama": ["llama2", "mixtral"],
+    },
+}
+
+# Empty models for testing empty response case
+EMPTY_MODELS: dict[str, Any] = {
+    "models": [],
+    "vendors": {},
+}
+
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
@@ -280,6 +304,27 @@ async def list_empty_strategies():
     """
     logger.info("Serving empty strategies list")
     return EMPTY_STRATEGIES
+
+
+@app.get("/models/names")
+async def list_models():
+    """Return list of available Fabric models by vendor.
+
+    This mimics the real Fabric API endpoint GET /models/names
+    """
+    logger.info("Serving models: %d total models", len(MOCK_MODELS["models"]))
+    return MOCK_MODELS
+
+
+@app.get("/models/names/empty")
+async def list_empty_models():
+    """Return empty list of models for testing empty response case.
+
+    This is a special test endpoint that returns an empty models list
+    to verify the MCP tool handles the empty case correctly.
+    """
+    logger.info("Serving empty models list")
+    return EMPTY_MODELS
 
 
 @app.post("/chat")

--- a/tests/shared/fabric_api_mocks.py
+++ b/tests/shared/fabric_api_mocks.py
@@ -115,6 +115,38 @@ class FabricApiMockBuilder:
         self.mock_response.json.return_value = strategies
         return self
 
+    def with_successful_models_list(
+        self,
+        models: list[str] | None = None,
+        vendors: dict[str, list[str]] | None = None,
+    ) -> "FabricApiMockBuilder":
+        """Configure mock for successful models list response.
+
+        Args:
+            models: List of all model names. Defaults to common test models.
+            vendors: Dict mapping vendor names to model lists.
+                Defaults to common test vendors.
+
+        Returns:
+            Self for method chaining
+        """
+        if models is None:
+            models = ["gpt-4o", "gpt-3.5-turbo", "claude-3-opus", "llama2"]
+
+        if vendors is None:
+            vendors = {
+                "openai": ["gpt-4o", "gpt-3.5-turbo"],
+                "anthropic": ["claude-3-opus"],
+                "ollama": ["llama2"],
+            }
+
+        response_data = {
+            "models": models,
+            "vendors": vendors,
+        }
+        self.mock_response.json.return_value = response_data
+        return self
+
     def with_raw_response_data(self, data: Any) -> "FabricApiMockBuilder":
         """Configure mock to return raw response data (for testing mixed types).
 


### PR DESCRIPTION
# feat: implement `fabric_list_models` MCP tool

## Summary

The core of this change is the implementation of the `fabric_list_models` method in `FabricMCP`. This method now makes an HTTP request to the `/models/names` endpoint of the connected Fabric API. To ensure robustness, the response from this API is thoroughly validated before being returned to the client. If the API returns data that does not conform to the expected structure, a specific `McpError` is raised with a descriptive message.

This functionality is supported by a comprehensive suite of new unit and integration tests.

## Files Changed

*   **`src/fabric_mcp/core.py`**: Implemented the `fabric_list_models` tool. The placeholder returning static data has been replaced with a call to the Fabric API and extensive validation logic.
*   **`src/fabric_mcp/__about__.py`**: Version bumped to `0.20.0` to reflect the new functionality.
*   **`tests/unit/test_core_coverage.py`**: Added a new suite of unit tests for `fabric_list_models`. These tests cover the success case, empty responses, and numerous failure scenarios where the Fabric API might return malformed data.
*   **`tests/integration/test_transport_integration.py`**: Enhanced the integration test for `fabric_list_models` to validate the tool's output against a mock Fabric API server.
*   **`tests/shared/fabric_api/server.py`**: Added mock data (`MOCK_MODELS`) and a new `/models/names` endpoint to the mock Fabric API server used in integration tests.
*   **`tests/shared/fabric_api_mocks.py`**: Extended the `FabricApiMockBuilder` with a `with_successful_models_list` method to simplify unit testing.
*   **`docs/`**: Updated story `4.1.story.md` status to "InProgress" and corrected a story number typo in the epic overview.

## Code Changes

The main logic resides in `src/fabric_mcp/core.py` within the `fabric_list_models` method. It now fetches data and performs strict validation.

```python
# src/fabric_mcp/core.py

    def fabric_list_models(self) -> dict[Any, Any]:
        """Retrieve configured Fabric models by vendor."""
        response_data = self._make_fabric_api_request(
            "/models/names", operation="retrieving models"
        )

        # Validate response data type
        if not isinstance(response_data, dict):
            raise McpError(
                ErrorData(
                    code=-32603,  # Internal error
                    message=(
                        "Invalid response from Fabric API: expected dict for models"
                    ),
                )
            )
        
        # ... additional validation for 'models' list, 'vendors' dict, and their contents ...

        # Return validated structure
        return {
            "models": cast(list[str], models),
            "vendors": cast(dict[str, list[str]], vendors),
        }
```

This structured validation ensures that the MCP layer is resilient to unexpected or invalid data from the upstream Fabric API, preventing potential crashes and providing clear error feedback.

## Reason for Changes

This change implements Story 4.1 ("Implement `fabric_list_models` MCP Tool"). This is a foundational feature that allows MCP clients to discover the capabilities of the connected Fabric instance, specifically which AI models are available for use. This is a prerequisite for more advanced interactions where a client might want to select a model dynamically.

## Impact of Changes

*   **Functionality**: The MCP now provides a functional `fabric_list_models` tool, moving it from a prototype stage to a usable feature.
*   **Robustness**: The strict validation of the API response makes the MCP more resilient. Any deviation from the expected contract by the Fabric API will result in a clean, well-defined `McpError` rather than a runtime exception or propagation of bad data.
*   **Testability**: The addition of mock server endpoints and test builders for this feature improves our ability to test this and future API-dependent tools in isolation.

## Test Plan

The changes have been thoroughly tested:

1.  **Unit Tests**: In `tests/unit/test_core_coverage.py`, a comprehensive set of tests has been added. These mock the `FabricApiClient` and verify that `fabric_list_models`:
    *   Correctly processes a valid API response.
    *   Handles an empty (but valid) API response.
    *   Raises the correct `McpError` for various types of malformed data, such as an incorrect top-level type, invalid `models` or `vendors` fields, or incorrect data types within those structures.
2.  **Integration Tests**: The test in `tests/integration/test_transport_integration.py` was updated to use a mock Fabric API server. It confirms that a client connected to the MCP server can successfully call the `fabric_list_models` tool and receive a correctly structured JSON response.

## Additional Notes

The choice to use a single error code (`-32603`, Internal Error) for all validation failures was deliberate. From the client's perspective, the key information is that the response from the Fabric service was malformed, and the detailed error message provides the specifics for debugging.