### PR TITLE
Update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dev = [
     "hatchling>=1.27.0",
     "pre-commit>=4.2.0",
     "pylint>=3.3.7",
-    "pylint-pytest>=1.1.8",
+    "pylint-pytest>=2.0.0a1",
     "pyright>=1.1.402",
     "pytest>=8.4.0",
     "pytest-asyncio>=1.0.0",
@@ -67,6 +67,7 @@ markers = ["integration: marks tests as integration tests"]
 path = "src/fabric_mcp/__about__.py"
 
 [tool.uv]
+prerelease = "if-necessary-or-explicit"
 index = [
     { name = "testpypi", url = "https://test.pypi.org/simple/", publish-url = "https://test.pypi.org/legacy/", explicit = true },
     { name = "pypi", url = "https://pypi.org/simple/", publish-url = "https://upload.pypi.org/legacy/", explicit = true },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ markers = ["integration: marks tests as integration tests"]
 path = "src/fabric_mcp/__about__.py"
 
 [tool.uv]
-prerelease = "if-necessary-or-explicit"
 index = [
     { name = "testpypi", url = "https://test.pypi.org/simple/", publish-url = "https://test.pypi.org/legacy/", explicit = true },
     { name = "pypi", url = "https://pypi.org/simple/", publish-url = "https://upload.pypi.org/legacy/", explicit = true },

--- a/src/fabric_mcp/__about__.py
+++ b/src/fabric_mcp/__about__.py
@@ -1,3 +1,3 @@
 "Version information for fabric_mcp."
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/uv.lock
+++ b/uv.lock
@@ -574,16 +574,17 @@ wheels = [
 
 [[package]]
 name = "cyclopts"
-version = "5.0.0a6"
+version = "4.11.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "docstring-parser" },
     { name = "rich" },
+    { name = "rich-rst" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/85/50f3ab8e645be7de39689d0ba8f9020009de3e15bd4cad26d11425f73a5d/cyclopts-5.0.0a6.tar.gz", hash = "sha256:e66ad6823c97e00dd4081277d9d5f95d9a67914750c595b9aae6ef2f93a7e17b", size = 171447, upload-time = "2026-03-23T14:51:23.769Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/f7/3ee212c1bc314551094fc8fda7b4b63c647ac5c32d06daa285d04d33edfc/cyclopts-4.11.2.tar.gz", hash = "sha256:8c9b77921660fa1ee52c150e2217ced672323efb3434e9b338077de1bc551ff4", size = 175935, upload-time = "2026-05-04T00:11:57.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/5e/61b12b46657a4cd38f07ed90aab2a6f4e6110448276826940defa0eb5830/cyclopts-5.0.0a6-py3-none-any.whl", hash = "sha256:2098634e797a498f561ee87429babfe4c16068d50e9ebfe6b35626207e741799", size = 209583, upload-time = "2026-03-23T14:51:24.795Z" },
+    { url = "https://files.pythonhosted.org/packages/23/18/4cedda786e7da429e7489549a9e5461530d4133130e541f25fb94f015776/cyclopts-4.11.2-py3-none-any.whl", hash = "sha256:838020120b939549ff7c8423aca29c86764b5dd1d8a5d7f3753a6327861f537b", size = 213537, upload-time = "2026-05-04T00:11:56.103Z" },
 ]
 
 [[package]]
@@ -629,6 +630,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.22.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
 ]
 
 [[package]]
@@ -718,7 +728,7 @@ dev = [
     { name = "hatchling", specifier = ">=1.27.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pylint", specifier = ">=3.3.7" },
-    { name = "pylint-pytest", specifier = ">=1.1.8" },
+    { name = "pylint-pytest", specifier = ">=2.0.0a1" },
     { name = "pyright", specifier = ">=1.1.402" },
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
@@ -1669,15 +1679,15 @@ wheels = [
 
 [[package]]
 name = "pytest-asyncio"
-version = "1.4.0a2"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/7c/f0831e89e025cea4f7b0201743c02c1016d86b9d4d6e86da8d556f6e86e0/pytest_asyncio-1.4.0a2.tar.gz", hash = "sha256:7cdef3b22cdfe423829eb594a25f7c23c8b3ec2a82d014a56e5179038eb3e674", size = 57596, upload-time = "2026-05-02T07:40:45.489Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/0f/eebdc66222f6942fe2962894c419f14693cb2401bdb5c000b86742aab004/pytest_asyncio-1.4.0a2-py3-none-any.whl", hash = "sha256:b6f8c01beaca5dc05c88a95b7a9df7660da4cef319cf685d886af6715261e9d4", size = 16957, upload-time = "2026-05-02T07:40:43.636Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]
@@ -1873,6 +1883,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rich-rst"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/6d/a506aaa4a9eaa945ed8ab2b7347859f53593864289853c5d6d62b77246e0/rich_rst-1.3.2.tar.gz", hash = "sha256:a1196fdddf1e364b02ec68a05e8ff8f6914fee10fbca2e6b6735f166bb0da8d4", size = 14936, upload-time = "2025-10-14T16:49:45.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl", hash = "sha256:a99b4907cbe118cf9d18b0b44de272efa61f15117c61e39ebdc431baf5df722a", size = 12567, upload-time = "2025-10-14T16:49:42.953Z" },
 ]
 
 [[package]]
@@ -2229,7 +2252,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.3.1"
+version = "21.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -2237,9 +2260,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/0d/915c02c94d207b85580eb09bffab54438a709e7288524094fe781da526c2/virtualenv-21.3.1.tar.gz", hash = "sha256:c2305bc1fddeec40699b8370d13f8d431b0701f00ce895061ce493aeded4426b", size = 7613791, upload-time = "2026-05-05T01:34:31.402Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/e1/665267cea4767debd19f584667a9197c2098b5e7f67a502da9f3a086ab37/virtualenv-21.3.2.tar.gz", hash = "sha256:3ecda97894a6fc1c53106356f488690e5c86278c1f693f3fc0805ac85a513686", size = 7613810, upload-time = "2026-05-12T14:44:18.01Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/4f/f71e641e504111a5a74e3a20bc52d01bd86788b22699dd3fee1c63253cf6/virtualenv-21.3.1-py3-none-any.whl", hash = "sha256:d1a71cf58f2f9228fff23a1f6ec15d39785c6b32e03658d104974247145edd35", size = 7594539, upload-time = "2026-05-05T01:34:28.98Z" },
+    { url = "https://files.pythonhosted.org/packages/20/5b/885f479093f6627669d39b57bc3d4e674da532e1a4b247d473a61d8d2118/virtualenv-21.3.2-py3-none-any.whl", hash = "sha256:c58ea748fa50bb2a4367da5ba3d30b02458ed40b4ea888faad94021f3309f764", size = 7594558, upload-time = "2026-05-12T14:44:15.193Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Update dependencies

## Summary

This PR bumps the package version from `1.2.0` to `1.2.1` and updates development dependency metadata. The primary dependency change is upgrading `pylint-pytest` to `>=2.0.0a1`, with the lockfile refreshed to reflect the resulting dependency resolution.

## Files Changed

### `pyproject.toml`

Updated the development dependency constraint for `pylint-pytest`.

### `src/fabric_mcp/__about__.py`

Bumped the project version to `1.2.1`.

### `uv.lock`

Refreshed the lockfile after dependency updates. This includes changes to resolved package versions and new transitive dependencies.

## Code Changes

### `pyproject.toml`

The development dependency for `pylint-pytest` was updated:

```toml
-    "pylint-pytest>=1.1.8",
+    "pylint-pytest>=2.0.0a1",
```

This allows the project to use the newer `pylint-pytest` release line.

### `src/fabric_mcp/__about__.py`

The package version was bumped:

```python
-__version__ = "1.2.0"
+__version__ = "1.2.1"
```

### `uv.lock`

The lockfile was regenerated and includes the following notable changes:

- `pylint-pytest` requirement updated from `>=1.1.8` to `>=2.0.0a1`
- `cyclopts` resolved from `5.0.0a6` to `4.11.2`
- `pytest-asyncio` resolved from `1.4.0a2` to `1.3.0`
- `virtualenv` resolved from `21.3.1` to `21.3.2`
- Added new transitive dependencies:
  - `docutils`
  - `rich-rst`

Example lockfile dependency addition:

```toml
[[package]]
name = "rich-rst"
version = "1.3.2"
dependencies = [
    { name = "docutils" },
    { name = "rich" },
]
```

## Reason for Changes

The dependency update enables compatibility with the newer `pylint-pytest` release line. The version bump to `1.2.1` indicates this is a patch-level release.

The lockfile refresh ensures the repository has a reproducible dependency set that matches the updated dependency constraints.

## Impact of Changes

This change primarily affects the development environment and tooling. Runtime behavior of the package should remain unchanged because no application source code was modified beyond the version metadata.

Potential impacts:

- Lint behavior for pytest-related code may change due to the `pylint-pytest` update.
- Dependency resolution now includes `rich-rst` and `docutils` through the resolved `cyclopts` version.
- Some development dependencies moved away from alpha versions, such as:
  - `cyclopts`: `5.0.0a6` to `4.11.2`
  - `pytest-asyncio`: `1.4.0a2` to `1.3.0`

## Test Plan

Recommended validation:

- Install dependencies from the refreshed lockfile:

```bash
uv sync
```

- Run the test suite:

```bash
uv run pytest
```

- Run linting to confirm the updated `pylint-pytest` behavior is compatible with the codebase:

```bash
uv run pylint src tests
```

- Optionally run type checking:

```bash
uv run pyright
```

## Additional Notes

No functional application code was changed in this PR. The main risk is development tooling behavior changing due to the updated lint plugin and refreshed dependency resolution.
